### PR TITLE
convert to georchestra datadir model and build a debian/rpm package

### DIFF
--- a/cadastrapp/README.md
+++ b/cadastrapp/README.md
@@ -128,6 +128,15 @@ for exemple : ```schema.name=cadastreapp```
 mvn clean install
 ```
 
+##  Build a debian package :
+
+To ease deployment and use the georchestra datadir, you can also build and deploy a debian package:
+```
+mvn clean package deb:package -pl cadastrapp -PdebianPackage
+```
+
+This will produce a .deb file under ```cadastrapp/target/```
+
 ##  Deploy application : 
 
 Copy war build previously in tomcat-cadastrapp webapps folder

--- a/cadastrapp/pom.xml
+++ b/cadastrapp/pom.xml
@@ -37,16 +37,6 @@
 			<name>OpenGeo Maven Repository</name>
 			<url>http://repo.opengeo.org</url>
 		</repository>
-<!--
-		<repository>
-			<snapshots>
-				<enabled>true</enabled>
-				<checksumPolicy>ignore</checksumPolicy>
-			</snapshots>
-			<id>georchestra</id>
-			<url>http://build.georchestra.org/maven/repository</url>
-		</repository>
--->
 	</repositories>
 	<dependencies>
 		<dependency>
@@ -95,14 +85,6 @@
 			<artifactId>spring-data-jpa</artifactId>
 			<version>1.9.0.RELEASE</version>
 		</dependency>
-		<!-- geOrchestra commons -->
-<!--
-		<dependency>
-			<groupId>org.georchestra</groupId>
-			<artifactId>georchestra-commons</artifactId>
-			<version>15.12-SNAPSHOT</version>
-		</dependency>
--->
 		<!-- Spring JDBC Support -->
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -287,13 +269,6 @@
 		</dependency>
 	</dependencies>
 	<pluginRepositories>
-<!--
-		<pluginRepository>
-			<id>opengeo</id>
-			<name>OpenGeo Maven Repository</name>
-			<url>http://repo.boundlessgeo.com/main/</url>
-		</pluginRepository>
--->
 	</pluginRepositories>
 	<build>
 		<pluginManagement>

--- a/cadastrapp/pom.xml
+++ b/cadastrapp/pom.xml
@@ -37,6 +37,16 @@
 			<name>OpenGeo Maven Repository</name>
 			<url>http://repo.opengeo.org</url>
 		</repository>
+<!--
+		<repository>
+			<snapshots>
+				<enabled>true</enabled>
+				<checksumPolicy>ignore</checksumPolicy>
+			</snapshots>
+			<id>georchestra</id>
+			<url>http://build.georchestra.org/maven/repository</url>
+		</repository>
+-->
 	</repositories>
 	<dependencies>
 		<dependency>
@@ -85,6 +95,14 @@
 			<artifactId>spring-data-jpa</artifactId>
 			<version>1.9.0.RELEASE</version>
 		</dependency>
+		<!-- geOrchestra commons -->
+<!--
+		<dependency>
+			<groupId>org.georchestra</groupId>
+			<artifactId>georchestra-commons</artifactId>
+			<version>15.12-SNAPSHOT</version>
+		</dependency>
+-->
 		<!-- Spring JDBC Support -->
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -269,6 +287,13 @@
 		</dependency>
 	</dependencies>
 	<pluginRepositories>
+<!--
+		<pluginRepository>
+			<id>opengeo</id>
+			<name>OpenGeo Maven Repository</name>
+			<url>http://repo.boundlessgeo.com/main/</url>
+		</pluginRepository>
+-->
 	</pluginRepositories>
 	<build>
 		<pluginManagement>
@@ -389,4 +414,141 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>debianPackage</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-war-plugin</artifactId>
+						<version>2.2</version>
+					<configuration>
+						<webResources>
+							<resource>
+								<directory>target/site</directory>
+							</resource>
+							<resource>
+								<directory>target/generated</directory>
+								<targetPath>apidocs</targetPath>
+							</resource>
+						</webResources>
+					</configuration>
+					</plugin>
+					<plugin>
+						<artifactId>maven-resources-plugin</artifactId>
+						<version>2.3</version>
+						<executions>
+							<execution>
+								<id>copy-deb-resources</id>
+								<phase>process-resources</phase>
+								<goals><goal>copy-resources</goal></goals>
+								<configuration>
+									<overwrite>true</overwrite>
+									<outputDirectory>${basedir}/target/deb</outputDirectory>
+									<resources>
+										<resource>
+											<directory>src/deb/resources</directory>
+										</resource>
+									</resources>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-antrun-plugin</artifactId>
+						<version>1.6</version>
+						<executions>
+							<execution>
+								<id>fix-permissions</id>
+								<phase>package</phase>
+								<configuration>
+									<target>
+										<chmod perm="ugo+x">
+											<fileset dir="${basedir}/target/deb">
+												<include name="**/bin/**"/>
+												<include name="**/sbin/**"/>
+												<include name="DEBIAN/post*"/>
+												<include name="DEBIAN/pre*"/>
+											</fileset>
+										</chmod>
+									</target>
+								</configuration>
+								<goals><goal>run</goal></goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>net.sf.debian-maven</groupId>
+						<artifactId>debian-maven-plugin</artifactId>
+						<version>1.0.6</version>
+						<configuration>
+							<packageName>georchestra-${project.artifactId}</packageName>
+							<packageDescription>Cadastrapp webapp for geOrchestra</packageDescription>
+							<packageDependencies>
+								<packageDependency>debconf</packageDependency>
+							</packageDependencies>
+							<projectUrl>http://www.georchestra.org/</projectUrl>
+							<projectOrganization>geOrchestra</projectOrganization>
+							<maintainerName>Pierre Jego</maintainerName>
+							<maintainerEmail>pierre.jego@gfi.fr</maintainerEmail>
+							<excludeAllArtifacts>true</excludeAllArtifacts>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>rpmPackage</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-war-plugin</artifactId>
+					</plugin>
+					<plugin>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>rpm-maven-plugin</artifactId>
+						<version>2.1.3</version>
+						<executions>
+							<execution>
+								<id>generate-rpm</id>
+								<goals>
+									<goal>rpm</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<name>georchestra-${project.artifactId}</name>
+							<sourceEncoding>UTF-8</sourceEncoding>
+							<group>Applications/Internet</group>
+							<keyname>${rpm.gpg.key}</keyname>
+							<mappings>
+								<mapping>
+									<directory>/usr/share/lib/georchestra-${project.artifactId}</directory>
+									<sources>
+										<source>
+											<location>${project.build.directory}</location>
+											<includes>
+												<include>cadastrapp.war</include>
+											</includes>
+										</source>
+									</sources>
+								</mapping>
+								<mapping>
+									<directory>/</directory>
+									<sources>
+										<source>
+											<location>${basedir}/src/deb/resources</location>
+										</source>
+									</sources>
+								</mapping>
+							</mappings>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/cadastrapp/pom.xml
+++ b/cadastrapp/pom.xml
@@ -267,6 +267,11 @@
 			<artifactId>jstl</artifactId>
 			<version>1.2</version>
 		</dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>servlet-api</artifactId>
+			<version>2.4</version>
+		</dependency>
 	</dependencies>
 	<pluginRepositories>
 	</pluginRepositories>

--- a/cadastrapp/pom.xml
+++ b/cadastrapp/pom.xml
@@ -423,17 +423,10 @@
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-war-plugin</artifactId>
 						<version>2.2</version>
-					<configuration>
-						<webResources>
-							<resource>
-								<directory>target/site</directory>
-							</resource>
-							<resource>
-								<directory>target/generated</directory>
-								<targetPath>apidocs</targetPath>
-							</resource>
-						</webResources>
-					</configuration>
+						<configuration>
+							<classifier>generic</classifier>
+							<warName>${project.artifactId}</warName>
+						</configuration>
 					</plugin>
 					<plugin>
 						<artifactId>maven-resources-plugin</artifactId>

--- a/cadastrapp/src/deb/resources/etc/georchestra/cadastrapp/cadastrapp.properties
+++ b/cadastrapp/src/deb/resources/etc/georchestra/cadastrapp/cadastrapp.properties
@@ -1,0 +1,39 @@
+## Configuration file for cadastrapp
+
+schema.name=cadastrapp_qgis
+
+cnil1RoleName=ROLE_EL_CAD_CNIL1
+cnil2RoleName=ROLE_EL_CAD_CNIL2
+
+minNbCharForSearch=3
+
+# PDF generation
+pdf.imageHeight=550
+pdf.imageWidth=550
+pdf.dateValiditeDonnees=01/01/2014
+pdf.organisme=Un service du CRAIG
+
+## Use to create image for pdf on server side (could be use for client configuration as well)
+baseMap.WMS.url=http://osm.geobretagne.fr/service/wms?VERSION=1.1.1&Request=GetCapabilities&Service=WMS
+baseMap.layer.name=osm:google
+baseMap.format=image/png
+baseMap.SRS=EPSG:3857
+
+## information about WMS and WFS service 
+# Here you can configure the layer name and with field contains the parcelle Id depending if you are on Qgis or Arcopole model
+cadastre.wms.url=http://gd-cms-crai-001.fasgfi.fr/geoserver/wms
+cadastre.wfs.url=http://gd-cms-crai-001.fasgfi.fr/geoserver/wfs
+cadastre.layer.name=qgis:geo_parcelle
+cadastre.layer.idParcelle=geo_parcelle
+cadastre.format=image/png
+cadastre.SRS=EPSG:3857
+
+## used in inner call service to create image for pdf from fo file
+webapp.url.services=http://localhost:8080/cadastrapp/services/
+
+## Temp folder with write acces to create image and temporary files needed for pdf generation
+## This folder should be writtable by tomcat user
+tempFolder=/tmp
+
+
+

--- a/cadastrapp/src/deb/resources/etc/georchestra/cadastrapp/logback.xml
+++ b/cadastrapp/src/deb/resources/etc/georchestra/cadastrapp/logback.xml
@@ -1,0 +1,34 @@
+<configuration>
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d %-5level %logger{36} - %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<logger name="org.georchestra.cadastrapp" level="DEBUG" />
+	<logger name="org.geotools" level="INFO" />
+	<logger name="org.springframework" level="INFO" />
+	
+	<!--  database -->
+	<logger name="org.hibernate" level="INFO" />	
+	<logger name="org.springframework.jdbc.core.JdbcTemplate" level="TRACE" />
+	
+	<!--  services -->
+	<logger name="org.apache.cxf" level="INFO" />
+	
+	<!--  pdf generation -->
+	<logger name="org.apache.xmlgraphics" level="INFO" />
+	<logger name="org.apache.fop" level="INFO" />
+
+	<appender name="FILE" class="ch.qos.logback.core.FileAppender">
+		<file>/tmp/cadastrapp.log</file>
+		<encoder>
+			<pattern>%d [%thread] %-5level /%X{uri} - %X{user:-nouser} - %X{roles:-norole} -%logger{36} - %msg%n</pattern>
+		</encoder>
+	</appender>
+
+
+	<root level="DEBUG">
+		<appender-ref ref="FILE" />
+	</root>
+</configuration>

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/logging/ExternalConfigLoaderContextListener.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/logging/ExternalConfigLoaderContextListener.java
@@ -1,0 +1,33 @@
+package org.georchestra.cadastrapp.logging;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Simple utility listener to load certain properties before Spring Starts up.
+ *
+ * inspired from https://bowerstudios.com/node/896
+ *
+ */
+public class ExternalConfigLoaderContextListener implements ServletContextListener {
+	private static final Logger logger = LoggerFactory.getLogger(ExternalConfigLoaderContextListener.class);
+
+	@Override
+	public void contextInitialized(ServletContextEvent sce) {
+		String configLocation = System.getProperty("georchestra.datadir");
+		if (configLocation != null) {
+			try {
+				new LogBackConfigLoader(configLocation + "/cadastrapp/logback.xml");
+			} catch (Exception e) {
+				logger.error("Unable to read config file", e);
+			}
+		}
+	}
+
+	@Override
+	public void contextDestroyed(ServletContextEvent sce) {
+	}
+}

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/logging/LogBackConfigLoader.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/logging/LogBackConfigLoader.java
@@ -1,0 +1,44 @@
+package org.georchestra.cadastrapp.logging;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.core.joran.spi.JoranException;
+
+/**
+ * Simple Utility class for loading an external config file for logback
+ *
+ * inspired from https://bowerstudios.com/node/896
+ */
+public class LogBackConfigLoader {
+
+	private Logger logger = LoggerFactory.getLogger(LogBackConfigLoader.class);
+	
+	public LogBackConfigLoader(String externalConfigFileLocation) throws IOException, JoranException{
+		LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
+		
+		File externalConfigFile = new File(externalConfigFileLocation);
+		if (!externalConfigFile.exists()) {
+			throw new IOException("Logback External Config File Parameter does not reference a file that exists: " + externalConfigFileLocation);
+		} else {
+			if (!externalConfigFile.isFile()) {
+				throw new IOException("Logback External Config File Parameter exists, but does not reference a file:" + externalConfigFileLocation);
+			} else {
+				if (!externalConfigFile.canRead()) {
+					throw new IOException("Logback External Config File exists and is a file, but cannot be read: " + externalConfigFileLocation);
+				} else {
+					JoranConfigurator configurator = new JoranConfigurator();
+					configurator.setContext(lc);
+					lc.reset();
+					configurator.doConfigure(externalConfigFileLocation);
+					logger.info("Configured Logback with config file from: " + externalConfigFileLocation);
+				}
+			}
+		}
+	}
+}

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/CadController.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/CadController.java
@@ -23,7 +23,8 @@ import org.springframework.jdbc.core.JdbcTemplate;
  *
  */
 @Configuration
-@PropertySource("classpath:cadastrapp.properties")
+@PropertySource(value = {"classpath:cadastrapp.properties",
+			"file:${georchestra.datadir}/cadastrapp/cadastrapp.properties"}, ignoreResourceNotFound = true)
 public class CadController {
 	
 	@Bean

--- a/cadastrapp/src/main/webapp/WEB-INF/web.xml
+++ b/cadastrapp/src/main/webapp/WEB-INF/web.xml
@@ -7,6 +7,9 @@
         <param-value>WEB-INF/beans.xml</param-value>
     </context-param>
     <listener>
+        <listener-class>org.georchestra.cadastrapp.logging.ExternalConfigLoaderContextListener</listener-class>
+    </listener>
+    <listener>
         <listener-class>
                        org.springframework.web.context.ContextLoaderListener
        </listener-class>


### PR DESCRIPTION
This PR allows to build a debian package, shipping cadastrapp.properties under /etc/georchestra/cadastrapp like all other georchestra webapps do now in master. Might also build an rpm package via the correct maven profile but untested here.

The only modification to actual code is to tell `CadController.java` to try reading classpath:cadastrapp.properties _then_ cadastrapp.properties in georchestra datadir - that also means that `georchestra.datadir` should be defined in tomcat env, but this is now required in master.

According to the docs in http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/context/annotation/PropertySource.html and http://stackoverflow.com/questions/30764534/resolving-placeholder-within-propertysource/30766461#30766461 this should just 'do the right thing' - untested at runtime yet.
