### PR TITLE
Handle search filter property

### DIFF
--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/CadController.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/CadController.java
@@ -49,7 +49,7 @@ public class CadController {
 		this.cnil2RoleName = CadastrappPlaceHolder.getProperty("cnil2RoleName");
 		this.roleSeparator = CadastrappPlaceHolder.getProperty("roleSeparator");
 		this.minNbCharForSearch = Integer.parseInt(CadastrappPlaceHolder.getProperty("minNbCharForSearch"));
-		this.isSearchFiltered =  (CadastrappPlaceHolder.getProperty("user.search.are.filtered").equals("0") ? false : true);
+		this.isSearchFiltered =  (CadastrappPlaceHolder.getProperty("user.search.are.filtered").equals("1") ? true : false);
 	}
 	
 	/**


### PR DESCRIPTION
I don't know why but the equals("0") always return false, so actually we can't enable user to don't have search limitations.

If we set user.search.are.filtered to 0, isSearchFiltered still true.

Check if equals("1") seems to solve the problem.
