### PR TITLE
Correction de la requête de récupération des bâtiments

### DIFF
--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/BatimentController.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/BatimentController.java
@@ -53,7 +53,7 @@ public class BatimentController extends CadController {
 			StringBuilder queryBuilder = new StringBuilder();
 			
 			// CNIL Niveau 2
-			queryBuilder.append("select distinct hab.annee, pb.jannat, pb.invar, pb.descr, pb.dniv, pb.dpor, hab.ccoaff_lib, ");
+			queryBuilder.append("select distinct hab.annee, pb.jannat, pb.invar, pb.descr, pb.dniv, pb.dpor, pb.dvltrt, hab.ccoaff_lib, ");
 			queryBuilder.append("prop.comptecommunal, prop.dnupro, prop.ddenom, prop.dnomlp, prop.dprnlp, prop.epxnee, prop.dnomcp, prop.dprncp ");
 			queryBuilder.append("from ");
 			queryBuilder.append(databaseSchema);
@@ -61,11 +61,8 @@ public class BatimentController extends CadController {
 			queryBuilder.append(databaseSchema);
 			queryBuilder.append(".proprietaire prop, ");
 			queryBuilder.append(databaseSchema);
-			queryBuilder.append(".proprietaire_parcelle propar, ");
-			queryBuilder.append(databaseSchema);
 			queryBuilder.append(".deschabitation hab ");
-			queryBuilder.append(" where propar.parcelle = ? ");
-			queryBuilder.append(" and propar.comptecommunal = pb.comptecommunal");
+			queryBuilder.append(" where pb.parcelle = ? ");
 			queryBuilder.append(" and pb.comptecommunal = prop.comptecommunal ");
 			queryBuilder.append(" and pb.dnubat = ? and hab.invar = pb.invar ;");
 			


### PR DESCRIPTION
Cette modification corrige : 
- La récupération des bâtiments en utilisant directement l'attribut parcelle de la vue **proprietebatie**, avant pas mal de bâtiments n'étaient pas remontés
- La récupération du revenu de chaque batiment, en effet l'attribut dvltrt n'était pas remonté par la requete, et donc le champs laissé vide dans la fiche de parcelle
