### PR TITLE
Prise en charge de l'absence de données EDIGEO

### DIFF
--- a/addons/cadastrapp/js/detailUniteCadastrale.js
+++ b/addons/cadastrapp/js/detailUniteCadastrale.js
@@ -99,6 +99,10 @@ GEOR.Addons.Cadastre.displayFIUC = function(parcelleId) {
                 if (result[0].gparbat == '1') {
                     isBuilding = OpenLayers.i18n('cadastrapp.yes')
                 }
+				// Check if EDIGEO is available
+				if(result[0].surfc == undefined) {
+					result[0].surfc = OpenLayers.i18n('cadastrapp.no_edigeo');
+				}
                 // Remplissage du tableau de données
                 fiucParcelleData = [ 
 					[ OpenLayers.i18n('cadastrapp.ficu.commune'), result[0].libcom + ' (' + result[0].cgocommune + ')' ], 

--- a/addons/cadastrapp/js/selectFeature.js
+++ b/addons/cadastrapp/js/selectFeature.js
@@ -549,6 +549,7 @@ GEOR.Addons.Cadastre.zoomOnFeatures = function(features) {
         map.zoomToExtent([ minLeft, minBottom, maxRight, maxTop ]); // zoom sur
         // l'emprise
     } else {
+		alert(OpenLayers.i18n('cadastrapp.no_feature'));
         console.log("No feature in input, could not zoom on it");
     }
 }

--- a/addons/cadastrapp/manifest.json
+++ b/addons/cadastrapp/manifest.json
@@ -378,7 +378,10 @@
 			"cadastrapp.infobulle.nplan" : "Plot",
 			"cadastrapp.infobulle.adresse" : "Adress",
 			"cadastrapp.infobulle.proprietaire" : "Owner",
-			"cadastrapp.infobulle.ccomunal" : "Municipal account"
+			"cadastrapp.infobulle.ccomunal" : "Municipal account",
+			
+			"cadastrapp.no_feature" : "Unable to locate the geometry, please select at least one.\nIf this is already the case, this may be due to the incompleteness of EDIGEO file.",
+			"cadastrapp.no_edigeo" : "No corresponding EDIGEO"
         },
         "fr": {
        		"cadastrapp.no": "non",
@@ -735,7 +738,10 @@
 			"cadastrapp.infobulle.nplan" : "N° de plan",
 			"cadastrapp.infobulle.adresse" : "Adresse",
 			"cadastrapp.infobulle.proprietaire" : "Propriétaire",
-			"cadastrapp.infobulle.ccomunal" : "Compte communal"
+			"cadastrapp.infobulle.ccomunal" : "Compte communal",
+			
+			"cadastrapp.no_feature" : "Impossible de retrouver la géometrie, veuillez en sélectionner au moins une.\nSi c'est déjà le cas, ceci peut être dû à une incompletude du fichier EDIGEO.",
+			"cadastrapp.no_edigeo" : "Pas d'EDIGEO correspondant"
         }
     }
 }


### PR DESCRIPTION
Résoud le cas où une parcelle est présente dans les données MAJIC, mais n'as pas de correspondance dans le fichier EDIGEO.
- Remplacement de la contenance SIG par un message disant qu'il n'y a pas de données EDIGEO associée
- Ajout d'une popup alert si on clique sur recentrer et qu'aucune parcelle n'est sélectionnée ou si aucune données geometrique n'est trouvée.

Cf. https://github.com/georchestra/cadastrapp/issues/205

En revanche, je n'ai pas d'exemple pour le cas contraire pour lequel tester une prise en charge.
