### PR TITLE
Ship mapfishapp cadastrapp addon in the debian package

### DIFF
--- a/cadastrapp/pom.xml
+++ b/cadastrapp/pom.xml
@@ -479,6 +479,29 @@
 									</resources>
 								</configuration>
 							</execution>
+							<execution>
+								<id>copy-deb-resources-mfapp</id>
+								<phase>process-resources</phase>
+								<goals>
+									<goal>copy-resources</goal>
+								</goals>
+								<configuration>
+									<overwrite>true</overwrite>
+									<outputDirectory>${basedir}/target/deb/etc/georchestra/mapfishapp/addons/cadastrapp</outputDirectory>
+									<resources>
+										<resource>
+											<directory>../addons/cadastrapp</directory>
+											<includes>
+												<include>**/js/**/*.js</include>
+												<include>**/css/**/*.css</include>
+												<include>**/img/**/*.png</include>
+												<include>**/manifest.json</include>
+												<include>**/config.json</include>
+											</includes>
+										</resource>
+									</resources>
+								</configuration>
+							</execution>
 						</executions>
 					</plugin>
 					<plugin>


### PR DESCRIPTION
I'm not sure this is a good idea or not - @jusabatier are you using the debian package, and what do you think about shipping the js addon directly with it, possibly overriding another existing version in the datadir/webapp ?

cc @pmauduit & @fvanderbiest for feedback too..
