### PR TITLE
Ajout du support des copropriétaires aux DI

### DIFF
--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/pdf/BordereauParcellaireHelper.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/pdf/BordereauParcellaireHelper.java
@@ -375,19 +375,31 @@ public final class BordereauParcellaireHelper extends CadController{
 		// if search by dnuproList or comptecommunal
 		// directly search in view parcelle
 		if(commune != null || ownerName != null){
+			queryBuilder.append("(");
 			queryBuilder.append("select distinct ");
 			queryBuilder.append("propar.parcelle ");
 			queryBuilder.append("from ");
 			queryBuilder.append(databaseSchema);
 			queryBuilder.append(".proprietaire p ,");
 			queryBuilder.append(databaseSchema);
-			queryBuilder.append(".proprietaire_parcelle propar ");
+			queryBuilder.append(".proprietaire_parcelle propar ,");
 			queryBuilder.append(" where p.comptecommunal = propar.comptecommunal ");
 			queryBuilder.append(" and p.cgocommune = ? and p.ddenom = ? ");
+			queryBuilder.append(") UNION (");
+			queryBuilder.append("select distinct ");
+			queryBuilder.append("copropar.parcelle ");
+			queryBuilder.append("from ");
+			queryBuilder.append(databaseSchema);
+			queryBuilder.append(".proprietaire p ,");
+			queryBuilder.append(databaseSchema);
+			queryBuilder.append(".co_propriete_parcelle copropar ,");
+			queryBuilder.append(" where p.comptecommunal = copropar.comptecommunal ");
+			queryBuilder.append(" and p.cgocommune = ? and p.ddenom = ? ");
+			queryBuilder.append(")");
 			queryBuilder.append(";");
 			
 			JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-			parcelles = jdbcTemplate.queryForList(queryBuilder.toString(), commune,ownerName);
+			parcelles = jdbcTemplate.queryForList(queryBuilder.toString(),commune,ownerName,commune,ownerName);
 		}
 		else{
 			logger.info("Missing or empty input parameter");

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/pdf/BordereauParcellaireHelper.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/pdf/BordereauParcellaireHelper.java
@@ -382,7 +382,7 @@ public final class BordereauParcellaireHelper extends CadController{
 			queryBuilder.append(databaseSchema);
 			queryBuilder.append(".proprietaire p ,");
 			queryBuilder.append(databaseSchema);
-			queryBuilder.append(".proprietaire_parcelle propar ,");
+			queryBuilder.append(".proprietaire_parcelle propar");
 			queryBuilder.append(" where p.comptecommunal = propar.comptecommunal ");
 			queryBuilder.append(" and p.cgocommune = ? and p.ddenom = ? ");
 			queryBuilder.append(") UNION (");
@@ -392,7 +392,7 @@ public final class BordereauParcellaireHelper extends CadController{
 			queryBuilder.append(databaseSchema);
 			queryBuilder.append(".proprietaire p ,");
 			queryBuilder.append(databaseSchema);
-			queryBuilder.append(".co_propriete_parcelle copropar ,");
+			queryBuilder.append(".co_propriete_parcelle copropar");
 			queryBuilder.append(" where p.comptecommunal = copropar.comptecommunal ");
 			queryBuilder.append(" and p.cgocommune = ? and p.ddenom = ? ");
 			queryBuilder.append(")");


### PR DESCRIPTION
Avec ce patch, dans les demandes d'informations, le choix d'un copropriétaire dans la liste déroulante du type d'objet "Proprietaire" est correctement géré. (Le bordereau parcellaire est correctement généré)

Corrige https://github.com/georchestra/cadastrapp/issues/239
