### PR TITLE
Maven - some improvements

### DIFF
--- a/cadastrapp/addon-assembly.xml
+++ b/cadastrapp/addon-assembly.xml
@@ -1,0 +1,14 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+  <id>addon</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <baseDirectory>/</baseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>${project.basedir}/target/addon</directory>
+      <outputDirectory>/</outputDirectory>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/cadastrapp/pom.xml
+++ b/cadastrapp/pom.xml
@@ -303,6 +303,29 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>3.0.0</version>
+          <executions>
+            <execution>
+              <id>cleaning-jsbuild-addon</id>
+              <phase>clean</phase>
+              <goals>
+                <goal>clean</goal>
+              </goals>
+              <configuration>
+                <filesets>
+                  <fileset>
+                    <directory>${project.parent.basedir}/addons/cadastrapp/js/build</directory>
+                    <includes>
+                      <include>**</include>
+                    </includes>
+                  </fileset>
+                </filesets>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-maven-plugin</artifactId>
           <version>9.2.11.v20150529</version>

--- a/cadastrapp/pom.xml
+++ b/cadastrapp/pom.xml
@@ -435,6 +435,49 @@
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>2.3</version>
+        <executions>
+          <execution>
+            <id>copy-mapfishapp-addon-files</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <overwrite>true</overwrite>
+              <outputDirectory>${basedir}/target/addon</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${project.parent.basedir}/addons/cadastrapp</directory>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>2.6</version>
+        <configuration>
+          <descriptors>
+            <descriptor>addon-assembly.xml</descriptor>
+          </descriptors>
+        </configuration>
+        <executions>
+          <execution>
+            <id>make-assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-java2wadl-plugin</artifactId>
         <version>${cxf.version}</version>

--- a/cadastrapp/src/docker/Dockerfile
+++ b/cadastrapp/src/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN  unzip -d /var/lib/jetty/webapps/cadastrapp /var/lib/jetty/webapps/cadastrap
   cp /etc/georchestra/cadastrapp/jetty-env.xml /var/lib/jetty/webapps/cadastrapp/WEB-INF/
 
 CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty -Dgeorchestra.datadir=/etc/georchestra \
- -Dmapfish-print-config=/etc/georchestra/mapfishapp/print/config.yaml -Xmx$XMX -Xms$XMX        \
+ -Xmx${XMX:-512m} -Xms${XMX:-512m}                                                             \
  $TRUSTORE_PASSWORD $TRUSTSTORE_PATH                                                           \
  -jar /usr/local/jetty/start.jar"]
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.georchestra</groupId>
-	<artifactId>cadastrapp-parent</artifactId>
-	<version>1.3-SNAPSHOT</version>
-	<packaging>pom</packaging>
-	<modules>
-		<module>cadastrapp</module>
-	</modules>
-	<url>https://github.com/GFI-Informatique/cadastrapp</url>
-	<name>Addons Cadastre pour georchestra</name>
-	<description>Ce projet est la partie serveur de l'addon cadastrapp pour la suite georchestra</description>
-	<organization>
-		<name>Gfi</name>
-		<url>https://github.com/GFI-Informatique</url>
-	</organization>
-	<scm>
-		<connection>scm:git:https://github.com/GFI-Informatique/cadastrapp.git</connection>
-		<developerConnection>scm:git:https://github.com/GFI-Informatique/cadastrapp.git</developerConnection>
-		<url>https://github.com/GFI-Informatique/cadastrapp.git</url>
-	</scm>
-	<issueManagement>
-		<system>GitHub Issues</system>
-		<url>https://github.com/GFI-Informatique/cadastrapp/issues</url>
-	</issueManagement>
-	 <build>
-      <plugins>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.georchestra</groupId>
+  <artifactId>cadastrapp-parent</artifactId>
+  <version>1.3-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <modules>
+    <module>cadastrapp</module>
+  </modules>
+  <url>https://github.com/GFI-Informatique/cadastrapp</url>
+  <name>Addons Cadastre pour georchestra</name>
+  <description>Ce projet est la partie serveur de l'addon cadastrapp pour la suite georchestra</description>
+  <organization>
+    <name>Gfi</name>
+    <url>https://github.com/GFI-Informatique</url>
+  </organization>
+  <scm>
+    <connection>scm:git:https://github.com/GFI-Informatique/cadastrapp.git</connection>
+    <developerConnection>scm:git:https://github.com/GFI-Informatique/cadastrapp.git</developerConnection>
+    <url>https://github.com/GFI-Informatique/cadastrapp.git</url>
+  </scm>
+  <issueManagement>
+    <system>GitHub Issues</system>
+    <url>https://github.com/GFI-Informatique/cadastrapp/issues</url>
+  </issueManagement>
+  <build>
+    <plugins>
        <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-scm-plugin</artifactId>


### PR DESCRIPTION
This PR addresses several things:
- When calling `mvn clean`, the jsbuild generated file will also be removed (the one in `addons/cadastrapp/js/build/cadastrapp.js`), this to restore a coherent state with the git repo after a cleanup.
- The maven process in the child module `cadastrapp` will now generate 2 artifacts:
  *\* a webapp WAR (as it was expected before)
  *\* a zip file containing all the resources needed for the addon (ready to be deployed either in the datadir, or in a deployed mapfishapp webapp into `app/addons`)
- Defining a default value for XMX parameter in the dockerfile, so that the container won't crash if undefined

This was mainly inspired from the urbanisme addon from rennes-metropole 
