### PR TITLE
deb package - package name stability

### DIFF
--- a/cadastrapp/pom.xml
+++ b/cadastrapp/pom.xml
@@ -644,6 +644,7 @@
 							<maintainerName>Pierre Jego</maintainerName>
 							<maintainerEmail>pierre.jego@gfi.fr</maintainerEmail>
 							<excludeAllArtifacts>true</excludeAllArtifacts>
+                                                        <snapshotRevisionFile>${project.build.directory}</snapshotRevisionFile>
 						</configuration>
 					</plugin>
 				</plugins>


### PR DESCRIPTION
See https://github.com/georchestra/georchestra/pull/1266 for the motivation.

Here is an output of the official geOr CI, WIP to generate debian packages for cadastrapp:

```
[WARNING] dpkg-deb: building package `georchestra-cadastrapp' in
`/home/jenkins/jobs/georchestra-pipelines/jobs/cadastrapp-pipeline/workspace/cadastrapp/target/georchestra-cadastrapp_1.4+201701081415+2-1_all.deb'.
[...]
[INFO] --- debian-maven-plugin:1.0.6:deploy (default-cli) @ cadastrapp
---
[INFO] Skipping deployment of non-existent package:
/home/jenkins/jobs/georchestra-pipelines/jobs/cadastrapp-pipeline/workspace/cadastrapp/target/georchestra-cadastrapp_1.4+201701081416+2-1_all.deb
```

Using the added directive in the pom makes use of the current build directory timestamp for the generated version number instead of the current date/time.