### PR TITLE
Correction du filtre commune pour l'export de propriétaire/copropriétaire

### DIFF
--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/CoProprietaireController.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/CoProprietaireController.java
@@ -232,12 +232,12 @@ public class CoProprietaireController extends CadController {
 				queryBuilder.append(".co_propriete_parcelle proparc ");
 				queryBuilder.append(createWhereInQuery(parcelleList.length, "proparc.parcelle"));
 				queryBuilder.append(" and prop.comptecommunal = proparc.comptecommunal ");
+				queryBuilder.append(addAuthorizationFiltering(headers));
 				queryBuilder.append("GROUP BY prop.comptecommunal, ccoqua_lib, dnomus, dprnus, dnomlp, dprnlp, ddenom, app_nom_usage, dlign3, dlign4, dlign5, dlign6, ccodro_lib ");
 				// If user is CNIL2 add birth information
 				if(getUserCNILLevel(headers)>1){
 					queryBuilder.append(", dldnss, jdatnss ");
 				}
-				queryBuilder.append(addAuthorizationFiltering(headers));
 				queryBuilder.append(" ORDER BY prop.comptecommunal");
 				
 				JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/ProprietaireController.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/ProprietaireController.java
@@ -357,12 +357,12 @@ public class ProprietaireController extends CadController{
 				queryBuilder.append(".proprietaire_parcelle proparc ");
 				queryBuilder.append(createWhereInQuery(parcelleList.length, "proparc.parcelle"));
 				queryBuilder.append(" and prop.comptecommunal = proparc.comptecommunal ");
+				queryBuilder.append(addAuthorizationFiltering(headers));
 				queryBuilder.append("GROUP BY prop.comptecommunal, ccoqua_lib, dnomus, dprnus, dnomlp, dprnlp, ddenom, app_nom_usage, dlign3, dlign4, dlign5, dlign6, ccodro_lib ");
 				// If user is CNIL2 add birth information
 				if(getUserCNILLevel(headers)>1){
 					queryBuilder.append(", dldnss, jdatnss ");
 				}
-				queryBuilder.append(addAuthorizationFiltering(headers));
 				queryBuilder.append(" ORDER BY prop.comptecommunal");
 				
 				JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);


### PR DESCRIPTION
Actuellement si un utilisateur ayant une limitation par commune essaye d'exporter un propriétaire/copropriétaire il a une erreur 500 à cause du SQL.

Un exemple : 

```
SELECT
	prop.comptecommunal, 
	ccoqua_lib, 
	dnomus, 
	dprnus, 
	dnomlp, 
	dprnlp, 
	ddenom, 
	app_nom_usage, 
	dlign3, 
	dlign4, 
	dlign5, 
	dlign6, 
	string_agg(parcelle, ','), 
	ccodro_lib , 
	dldnss, 
	jdatnss 
FROM
	cadastrapp.proprietaire prop, 
	cadastrapp.proprietaire_parcelle proparc  
WHERE 
	proparc.parcelle IN ($1,$2,$3,$4,$5,$6) 
	AND
	prop.comptecommunal = proparc.comptecommunal 
GROUP BY prop.comptecommunal, ccoqua_lib, dnomus, dprnus, dnomlp, dprnlp, ddenom, app_nom_usage, dlign3, dlign4, dlign5, dlign6, ccodro_lib , dldnss, jdatnss 
AND cgocommune IN ('430041' ) 
ORDER BY prop.comptecommunal
```

Le problème vient de l'insertion du filtre commune après le GROUP BY, ce qui cause une requete SQL invalide.