### PR TITLE
Rechargement des couches apres nettoyage de la carte

### DIFF
--- a/addons/cadastrapp/js/main.js
+++ b/addons/cadastrapp/js/main.js
@@ -79,6 +79,9 @@ GEOR.Addons.Cadastrapp = Ext.extend(GEOR.Addons.Base, {
         GEOR.Addons.Cadastre.result.owner.window;
 
         GEOR.Addons.Cadastre.createSelectionControl(this.options.defautStyleParcelle , this.options.selectedStyle);
+        
+        GEOR.wmc.events.on("aftercontextrestore", GEOR.Addons.Cadastre.restoreLayersOnClear, this);
+        GEOR.managelayers.events.on("aftercontextcleared", GEOR.Addons.Cadastre.restoreLayersOnClear, this);
 
         this.window = new Ext.Window({
             title: OpenLayers.i18n('cadastrapp.cadastre_tools'),
@@ -98,12 +101,13 @@ GEOR.Addons.Cadastrapp = Ext.extend(GEOR.Addons.Base, {
             listeners: {
                 "show": function() {
                     this.item.setChecked(true, true);
+                    GEOR.Addons.Cadastre.visible = true;
                     GEOR.Addons.Cadastre.addWMSLayer(WMSSetting);
                     GEOR.Addons.Cadastre.addPopupOnhover(this.options.popup);
                 },
                 "hide": function() {
-
                     this.item.setChecked(false, true);
+                    GEOR.Addons.Cadastre.visible = false;
                     // deactivate all controls create by cadastrapp addons
                     // All controls used by cadastrapp are store in the field GEOR.Addons.Cadastre.menu.cadastrappControls
                     Ext.each(GEOR.Addons.Cadastre.menu.cadastrappControls, function(control, index) {

--- a/addons/cadastrapp/js/selectFeature.js
+++ b/addons/cadastrapp/js/selectFeature.js
@@ -684,7 +684,7 @@ GEOR.Addons.Cadastre.restoreLayersOnClear = function() {
     var layersList = [];
     layersList.push(GEOR.Addons.Cadastre.WFSLayer);
     if( GEOR.Addons.Cadastre.visible ) {
-        layersList.push(GEOR.Addons.Cadastre.WMSLayer);
+        GEOR.Addons.Cadastre.addWMSLayer(this.options.WMSLayer);
     }
     var reader = new GeoExt.data.LayerReader();
     var layerData = reader.readRecords(layersList);

--- a/addons/cadastrapp/js/selectFeature.js
+++ b/addons/cadastrapp/js/selectFeature.js
@@ -98,7 +98,7 @@ GEOR.Addons.Cadastre.createSelectionControl = function(style, selectedStyle) {
         },
         trigger : function(e) {
             // récupération de la longitude et latitude à partir du clique
-            lonlat = map.getLonLatFromPixel(e.xy);
+            lonlat = GeoExt.MapPanel.guess().map.getLonLatFromPixel(e.xy);
             GEOR.Addons.Cadastre.getFeaturesWFSSpatial("Point", lonlat.lon + "," + lonlat.lat, "clickSelector");
         }
     });
@@ -672,5 +672,23 @@ GEOR.Addons.Cadastre.addWMSLayer = function(wmsSetting) {
        GeoExt.MapPanel.guess().layers.add(layerData.records[0]);
 
     }
+}
 
+/**
+ * Method: restoreLayersOnClear
+ * 
+ * Add WFS/WMS layer to map and layerswitcher when the map layers/context are cleared
+ * 
+ */
+GEOR.Addons.Cadastre.restoreLayersOnClear = function() {
+    var layersList = [];
+    layersList.push(GEOR.Addons.Cadastre.WFSLayer);
+    if( GEOR.Addons.Cadastre.visible ) {
+        layersList.push(GEOR.Addons.Cadastre.WMSLayer);
+    }
+    var reader = new GeoExt.data.LayerReader();
+    var layerData = reader.readRecords(layersList);
+    layerData.records.forEach(function(value){
+        GeoExt.MapPanel.guess().layers.add(value);
+    });
 }


### PR DESCRIPTION
Depuis la release 16.12, MFapp dispose de 2 nouveaux events (https://github.com/georchestra/georchestra/pull/1639) : 

- aftercontextrestore : lorsque un utilisateur a chargé un contexte

- aftercontextcleared : lorsque un utilisateur a vidé la carte (bouton supprimer toutes les couches)

Actuellement lorsque un utilisateur fait cela, les couches WMS/WFS de l'addon sont supprimées aussi et il doit re-ouvrir l'addon pour recharger la couche WMS, mais il doit actualiser la page pour pouvoir réutiliser les fonctionnalités de zoom sur une/des parcelles. Certaines actions basées sur la carte sont également dès lors bugguées.

Avec ce patch les couches WMS/WFS sont automatiquement rechargées au chargement d'un contexte ou lorsque l'utilisateur supprime toutes les couches. La couche WMS est rechargée uniquement si l'addon cadastre est ouvert (popup visible).

J'ai testé ce patch sur une version 15.12 de MFapp et il n'a pas d'effet négatifs, les events n'étant pas lancés, le code ajouté n'est simplement pas appelé.

Cette PR réponds à  https://github.com/georchestra/cadastrapp/issues/321