### PR TITLE
URGENT : Correction d'une erreur de syntaxe javascript qui empêche l'execution

### DIFF
--- a/addons/cadastrapp/js/resultProprietaire.js
+++ b/addons/cadastrapp/js/resultProprietaire.js
@@ -53,7 +53,7 @@ GEOR.Addons.Cadastre.initResultProprietaireWindow = function() {
         listeners : {
             show: function(window){
                 window.alignTo(GeoExt.MapPanel.guess().map.div,"t",[0,150],false);
-            }
+            },
             close : function(window) {
                 GEOR.Addons.Cadastre.result.owner.window = null;
             }


### PR DESCRIPTION
Oubli d'une "," ligne 56 => erreur au chargement de cadastrapp

@pierrejego 