### PR TITLE
Properly handle sections with a prefix and a single-letter section co…

### DIFF
--- a/addons/cadastrapp/js/searchParcelleByRef.js
+++ b/addons/cadastrapp/js/searchParcelleByRef.js
@@ -475,8 +475,13 @@ GEOR.Addons.Cadastre.initRechercheParcelle = function() {
                                 if (record.data.parcelle != undefined && record.data.parcelle > 0 && record.data.section != undefined && record.data.section.length > 0) {
 
                                     params.dnupla = record.data.parcelle;
-                                    params.ccopre = record.data.section.substring(0, record.data.section.length - 2);
-                                    params.ccosec = record.data.section.substring(record.data.section.length - 2, record.data.section.length);
+                                    params.ccopre = '';
+                                    params.ccosec = record.data.section;
+                                    // section has a 3-digit prefix
+                                    if (record.data.section.length > 2) {
+                                        params.ccopre = record.data.section.substring(0, 3);
+                                        params.ccosec = record.data.section.substring(3);
+                                    }
 
                                     //envoi la liste de resultat
                                     Ext.Ajax.request({

--- a/addons/cadastrapp/js/searchUtils.js
+++ b/addons/cadastrapp/js/searchUtils.js
@@ -95,12 +95,17 @@ GEOR.Addons.Cadastre.initParcelleStore = function() {
  */
 GEOR.Addons.Cadastre.loadParcelleStore = function(parcelleStore, cgocommune, sectionId) {
         
-    console.log("loadParcelleStore : " + parcelleStore + ""+ cgocommune + ""+ sectionId);
+    console.log("loadParcelleStore : " + parcelleStore + " commune="+ cgocommune + " sectionId="+ sectionId);
     
     if (parcelleStore!=null && cgocommune!=null && sectionId!=null) {
         // parse sectionID to set params for request
-        var prefix = sectionId.substring(0, sectionId.length-2);
-        var section = sectionId.substring(sectionId.length-2, sectionId.length);
+        var prefix = '';
+        var section = sectionId;
+        // sectionId has 3 digits as prefix
+        if (sectionId.length > 2) {
+            prefix = sectionId.substring(0, 3);
+            section = sectionId.substring(3);
+        }
 			        
         parcelleStore.load({params: {
             cgocommune: cgocommune,


### PR DESCRIPTION
…de (fixes #357)

The current code wasnt properly handling a section with an id of '255A',
setting 25 for ccopre and 5A for ccosec.
If sectionId is more that 2 chars, then the first 3 *are* the prefix,
and the remainder is the actual section id.