### PR TITLE
Fix csv headers (closes #356)

### DIFF
--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/CoProprietaireController.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/CoProprietaireController.java
@@ -202,10 +202,9 @@ public class CoProprietaireController extends CadController {
 		// User need to be at least CNIL1 level
 		if (getUserCNILLevel(headers)>0){
 		
-			//TODO externalize entete
-			String  entete = "Compte communal;Civilité;Nom;Prénom;Nom d'usage;Prénom d'usage;Dénomination;Nom d'usage;Adresse ligne 3;Adresse ligne 4;Adresse ligne 5;Adresse ligne 6;Identifiants de parcelles;Code du droit réel";
+			String  entete = "proprio_id;droit_reel_libelle;denomination_usage;parcelles;civilite;nom_usage;prenom_usage;denomination_naissance;nom_naissance;prenom_naissance;adresse_ligne3;adresse_ligne4;adresse_ligne5;adresse_ligne6";
 			if(getUserCNILLevel(headers)>1){
-				entete = entete + ";Lieu de naissance;Date de naissance";
+				entete = entete + ";lieu_naissance; date_naissance";
 			}
 			
 			String[] parcelleList = StringUtils.split(parcelles, ',');
@@ -218,8 +217,7 @@ public class CoProprietaireController extends CadController {
 				List<Map<String,Object>> coproprietaires = new ArrayList<Map<String,Object>>();
 										
 				StringBuilder queryBuilder = new StringBuilder();
-				queryBuilder.append("select prop.comptecommunal, ccoqua_lib, dnomus, dprnus, dnomlp, dprnlp, ddenom, app_nom_usage, dlign3, dlign4, dlign5, dlign6, ");
-				queryBuilder.append("string_agg(parcelle, ','), ccodro_lib ");
+				queryBuilder.append("select prop.comptecommunal, ccodro_lib, app_nom_usage, string_agg(parcelle, ','), ccoqua_lib, dnomus, dprnus, ddenom, dnomlp, dprnlp, dlign3, dlign4, dlign5, dlign6 ");
 				
 				// If user is CNIL2 add birth information
 				if(getUserCNILLevel(headers)>1){
@@ -233,7 +231,7 @@ public class CoProprietaireController extends CadController {
 				queryBuilder.append(createWhereInQuery(parcelleList.length, "proparc.parcelle"));
 				queryBuilder.append(" and prop.comptecommunal = proparc.comptecommunal ");
 				queryBuilder.append(addAuthorizationFiltering(headers));
-				queryBuilder.append("GROUP BY prop.comptecommunal, ccoqua_lib, dnomus, dprnus, dnomlp, dprnlp, ddenom, app_nom_usage, dlign3, dlign4, dlign5, dlign6, ccodro_lib ");
+				queryBuilder.append("GROUP BY prop.comptecommunal, ccodro_lib, app_nom_usage, ccoqua_lib, dnomus, dprnus, ddenom, dnomlp, dprnlp, dlign3, dlign4, dlign5, dlign6");
 				// If user is CNIL2 add birth information
 				if(getUserCNILLevel(headers)>1){
 					queryBuilder.append(", dldnss, jdatnss ");

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/CoProprietaireController.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/CoProprietaireController.java
@@ -203,9 +203,9 @@ public class CoProprietaireController extends CadController {
 		if (getUserCNILLevel(headers)>0){
 		
 			//TODO externalize entete
-			String  entete = "Compte communal;Civilité;Nom;Prénom;Nom d'usage;Prénom d'usage;Dénominiation;Nom d'usage;Adresse ligne 3;Adresse ligne 4;Adresse ligne 5;Adresse ligne 6;Identitifiants de parcelles;ccodro_lib";
+			String  entete = "Compte communal;Civilité;Nom;Prénom;Nom d'usage;Prénom d'usage;Dénomination;Nom d'usage;Adresse ligne 3;Adresse ligne 4;Adresse ligne 5;Adresse ligne 6;Identifiants de parcelles;Code du droit réel";
 			if(getUserCNILLevel(headers)>1){
-				entete = entete + ";Lieu de naissance; Date de naissance";
+				entete = entete + ";Lieu de naissance;Date de naissance";
 			}
 			
 			String[] parcelleList = StringUtils.split(parcelles, ',');

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/ParcelleController.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/ParcelleController.java
@@ -563,7 +563,7 @@ public class ParcelleController extends CadController {
 		// Create empty content
 		ResponseBuilder response = Response.noContent();
 		
-			String entete = "Identifiant de parcelle;Commune;dnvoiri;dindic;cconvo;dvoilib;ccopre;ccosec;N° de plan;Contenance DGFiP en m²";
+			String entete = "Identifiant de parcelle;Commune;N° de voirie;Indice de répétition;Nature de voie;Libellé de voie;Préfixe de section;Section;N° de plan;Contenance DGFiP en m²";
 			
 			String[] parcelleArray = StringUtils.split(parcelles, ',');
 			List<String> parcelleList = new ArrayList<String>();

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/ParcelleController.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/ParcelleController.java
@@ -563,7 +563,7 @@ public class ParcelleController extends CadController {
 		// Create empty content
 		ResponseBuilder response = Response.noContent();
 		
-			String entete = "Identifiant de parcelle;Commune;N° de voirie;Indice de répétition;Nature de voie;Libellé de voie;Préfixe de section;Section;N° de plan;Contenance DGFiP en m²";
+			String entete = "parcelle; commune;voie_adr;voie_adr_cplmt;voie_type;voie_nom;section_prefixe;section;parcelle_num;contenance";
 			
 			String[] parcelleArray = StringUtils.split(parcelles, ',');
 			List<String> parcelleList = new ArrayList<String>();

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/ProprietaireController.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/ProprietaireController.java
@@ -328,10 +328,9 @@ public class ProprietaireController extends CadController{
 		if (getUserCNILLevel(headers)>0){
 			
 			// TODO externalize
-			// final String  entete = "comptecommunal;ccoqua_lib;dnomus;dprnus;dnomlp;dprnlp;ddenom;app_nom_usage;app_nom_naissance;dlign3;dling4;dling5;dling6;identitifiantsparcelles;ccodro_lib";	
-			String  entete = "Compte communal;Civilité;Nom;Prénom;Nom d'usage;Prénom d'usage;Dénominiation;Nom d'usage;Adresse ligne 3;Adresse ligne 4;Adresse ligne 5;Adresse ligne 6;Identitifiants de parcelles;ccodro_lib";
+			String  entete = "Compte communal;Civilité;Nom;Prénom;Nom d'usage;Prénom d'usage;Dénomination;Nom d'usage;Adresse ligne 3;Adresse ligne 4;Adresse ligne 5;Adresse ligne 6;Identifiants de parcelles;Code du droit réel";
 			if(getUserCNILLevel(headers)>1){
-				entete = entete + ";Lieu de naissance; Date de naissance";
+				entete = entete + ";Lieu de naissance;Date de naissance";
 			}
 			
 			String[] parcelleList = StringUtils.split(parcelles, ',');

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/ProprietaireController.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/ProprietaireController.java
@@ -327,10 +327,9 @@ public class ProprietaireController extends CadController{
 		// User need to be at least CNIL1 level
 		if (getUserCNILLevel(headers)>0){
 			
-			// TODO externalize
-			String  entete = "Compte communal;Civilité;Nom;Prénom;Nom d'usage;Prénom d'usage;Dénomination;Nom d'usage;Adresse ligne 3;Adresse ligne 4;Adresse ligne 5;Adresse ligne 6;Identifiants de parcelles;Code du droit réel";
+			String  entete = "proprio_id;droit_reel_libelle;denomination_usage;parcelles;civilite;nom_usage;prenom_usage;denomination_naissance;nom_naissance;prenom_naissance;adresse_ligne3;adresse_ligne4;adresse_ligne5;adresse_ligne6";
 			if(getUserCNILLevel(headers)>1){
-				entete = entete + ";Lieu de naissance;Date de naissance";
+				entete = entete + ";lieu_naissance; date_naissance";
 			}
 			
 			String[] parcelleList = StringUtils.split(parcelles, ',');
@@ -343,8 +342,8 @@ public class ProprietaireController extends CadController{
 				List<Map<String,Object>> proprietaires = new ArrayList<Map<String,Object>>();
 										
 				StringBuilder queryBuilder = new StringBuilder();
-				queryBuilder.append("select prop.comptecommunal, ccoqua_lib, dnomus, dprnus, dnomlp, dprnlp, ddenom, app_nom_usage, dlign3, dlign4, dlign5, dlign6, ");
-				queryBuilder.append("string_agg(parcelle, ','), ccodro_lib ");
+				queryBuilder.append("select prop.comptecommunal, ccodro_lib, app_nom_usage, string_agg(parcelle, ','), ccoqua_lib, dnomus, dprnus, ddenom, dnomlp, dprnlp, dlign3, dlign4, dlign5, dlign6 ");
+				
 				// If user is CNIL2 add birth information
 				if(getUserCNILLevel(headers)>1){
 					queryBuilder.append(", dldnss, jdatnss ");
@@ -357,7 +356,7 @@ public class ProprietaireController extends CadController{
 				queryBuilder.append(createWhereInQuery(parcelleList.length, "proparc.parcelle"));
 				queryBuilder.append(" and prop.comptecommunal = proparc.comptecommunal ");
 				queryBuilder.append(addAuthorizationFiltering(headers));
-				queryBuilder.append("GROUP BY prop.comptecommunal, ccoqua_lib, dnomus, dprnus, dnomlp, dprnlp, ddenom, app_nom_usage, dlign3, dlign4, dlign5, dlign6, ccodro_lib ");
+				queryBuilder.append("GROUP BY prop.comptecommunal, ccodro_lib, app_nom_usage, ccoqua_lib, dnomus, dprnus, ddenom, dnomlp, dprnlp, dlign3, dlign4, dlign5, dlign6");
 				// If user is CNIL2 add birth information
 				if(getUserCNILLevel(headers)>1){
 					queryBuilder.append(", dldnss, jdatnss ");


### PR DESCRIPTION
- Fix typos: Dénominiation -> Dénomination, Identitifiants -> Identifiants
- remove extra space before 'Date de naissance'
- ccodro_lib -> Code du droit réel
- dnvoiri -> N° de voirie
- dindic -> Indice de répétition
- cconvo -> Nature de voie
- dvoilib -> Libellé de voie
- ccopre -> Préfixe de section
- ccosec -> Section