### PR TITLE
docker - fix dockerfile

### DIFF
--- a/cadastrapp/src/docker/Dockerfile
+++ b/cadastrapp/src/docker/Dockerfile
@@ -1,12 +1,16 @@
-FROM jetty:9.3-jre8
+FROM jetty:9.4-jre8
 
 ADD . /
 
 RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 
+USER root
+
 RUN  unzip -d /var/lib/jetty/webapps/cadastrapp /var/lib/jetty/webapps/cadastrapp.war && \
   rm -f /var/lib/jetty/webapps/cadastrapp.war &&                                         \
   cp /etc/georchestra/cadastrapp/jetty-env.xml /var/lib/jetty/webapps/cadastrapp/WEB-INF/
+
+USER jetty
 
 CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty -Dgeorchestra.datadir=/etc/georchestra \
  -Xmx${XMX:-512m} -Xms${XMX:-512m}                                                             \


### PR DESCRIPTION
To reflect some evolutions on the official docker Jetty image, we need to escalate as root user to uncompress the webapp and copy the jetty-env file.

Long story short: to be able to handle arm architecture, upstream jetty image had to drop a native library which was in charge to downgrade as jetty user when launching the servlet container. This caused the use of the "USER jetty" directive in the upstream dockerfile (everything was done as root before, and privileges were downgraded at runtime after bootstrap), but makes our dockerfile failing.

Also updated to a newer version of the image

Tests: tested on the C2C private CI, should not harm at runtime.