### PR TITLE
Evolution sur les lots demandé pour la version 1.6

### DIFF
--- a/addons/cadastrapp/js/detailUniteCadastrale.js
+++ b/addons/cadastrapp/js/detailUniteCadastrale.js
@@ -435,9 +435,11 @@ GEOR.Addons.Cadastre.displayFIUC = function(parcelleId) {
             fields : [ 'comptecommunal', 'dniv', 'dpor', 'ccoaff_lib', 'jannat', 'annee', 'app_nom_usage', 'app_nom_naissance', 'invar', 'revcad' ]
         });
 
+        var selectedBatiment;
+        
         // Récupère la liste des batiments de la parcelle
         Ext.Ajax.request({
-            url : GEOR.Addons.Cadastre.cadastrappWebappUrl + 'getFIC?parcelle=' + parcelleId + "&onglet=2",
+            url : GEOR.Addons.Cadastre.cadastrappWebappUrl + 'getBatimentsByParcelle?parcelle=' + parcelleId,
             method : 'GET',
             success : function(response) {
                 var result = Ext.decode(response.responseText);
@@ -454,6 +456,7 @@ GEOR.Addons.Cadastre.displayFIUC = function(parcelleId) {
                             enableToggle : true,
                             toggleHandler : function(btn, pressed) {
                                 if (pressed) {
+                                	selectedBatiment = btn.text;
                                     fiucBatimentsStore.load({
                                         params : {
                                             'dnubat' : btn.text,
@@ -560,16 +563,30 @@ GEOR.Addons.Cadastre.displayFIUC = function(parcelleId) {
                     selectedRecordsArray = fiucBatimentsGrid.getSelectionModel().getSelected();
 
                     if (selectedRecordsArray) {
-                        GEOR.Addons.Cadastre.showHabitationDetails('A', selectedRecordsArray.data.dniv, selectedRecordsArray.data.dpor, selectedRecordsArray.data.annee, selectedRecordsArray.data.invar);
+                        GEOR.Addons.Cadastre.showHabitationDetails(selectedBatiment, selectedRecordsArray.data.dniv, selectedRecordsArray.data.dpor, selectedRecordsArray.data.annee, selectedRecordsArray.data.invar);
                     } else {
                         Ext.Msg.show({title: 'Cadastrapp', icon: Ext.MessageBox.WARNING, msg:'Vous devez d\'abord sélectionner un batiment'});
                     }
                 }
-            } ],
+            } , {
+                iconCls : 'pdf-button',
+                scale: 'medium',
+                cls : 'x-btn-text-icon',
+                text : OpenLayers.i18n('cadastrapp.duc.batiment_bundle'),
+                handler : function() {
+                    if (selectedBatiment) {
+                    	var batiments = [];
+                    	batiments.push(selectedBatiment);
+                    	GEOR.Addons.Cadastre.onClickPrintLotsWindow(parcelleId, batiments);
+                    } else {
+                        Ext.Msg.show({title: 'Cadastrapp', icon: Ext.MessageBox.WARNING, msg:'Vous devez d\'abord sélectionner un batiment'});
+                    }
+                }
+            }],
             listeners: {
                 rowdblclick: function ( grid, rowIndex, e ) {
                     var row = grid.store.getAt(rowIndex);
-                    GEOR.Addons.Cadastre.showHabitationDetails('A', row.data.dniv, row.data.dpor, row.data.annee, row.data.invar);
+                    GEOR.Addons.Cadastre.showHabitationDetails(selectedBatiment, row.data.dniv, row.data.dpor, row.data.annee, row.data.invar);
                 }
             }
         });

--- a/addons/cadastrapp/js/main.js
+++ b/addons/cadastrapp/js/main.js
@@ -146,7 +146,7 @@ GEOR.Addons.Cadastrapp = Ext.extend(GEOR.Addons.Base, {
                         GEOR.Addons.Cadastre.result.owner.window=null;
                     }
 
-                    if ( GEOR.Addons.Cadastre.proprietaireWindow){
+                    if (GEOR.Addons.Cadastre.proprietaireWindow){
                         GEOR.Addons.Cadastre.proprietaireWindow.close();
                         GEOR.Addons.Cadastre.proprietaireWindow = null;
                     }
@@ -156,12 +156,12 @@ GEOR.Addons.Cadastrapp = Ext.extend(GEOR.Addons.Base, {
                         GEOR.Addons.Cadastre.rechercheParcelleWindow = null;
                     }
 
-                    if( GEOR.Addons.Cadastre.printBordereauParcellaireWindow){
+                    if(GEOR.Addons.Cadastre.printBordereauParcellaireWindow){
                         GEOR.Addons.Cadastre.printBordereauParcellaireWindow.close();
                         GEOR.Addons.Cadastre.printBordereauParcellaireWindow=null;
                     }
 
-                    if( GEOR.Addons.Cadastre.request.informationsWindow){
+                    if(GEOR.Addons.Cadastre.request.informationsWindow){
                         GEOR.Addons.Cadastre.request.informationsWindow.close();
                         GEOR.Addons.Cadastre.request.informationsWindow=null;
                     }
@@ -170,7 +170,16 @@ GEOR.Addons.Cadastrapp = Ext.extend(GEOR.Addons.Base, {
                         GEOR.Addons.Cadastre.coProprieteWindow.close();
                         GEOR.Addons.Cadastre.coProprieteWindow=null;
                     }
-
+                    
+                    if(GEOR.Addons.Cadastre.printReleveProprieteWindow){
+                    	GEOR.Addons.Cadastre.printReleveProprieteWindow.close();
+                    	GEOR.Addons.Cadastre.printReleveProprieteWindow=null;
+                    }
+                    
+                    if(GEOR.Addons.Cadastre.printLotsWindow){
+                    	GEOR.Addons.Cadastre.printLotsWindow.close();
+                    	GEOR.Addons.Cadastre.printLotsWindow=null;
+                    }
                 },
                 scope: this
             }

--- a/addons/cadastrapp/js/printLots.js
+++ b/addons/cadastrapp/js/printLots.js
@@ -1,0 +1,169 @@
+Ext.namespace("GEOR.Addons.Cadastre");
+
+/**
+ * onClickPrintLotsWindow
+ * 
+ * @param parcelleId String
+ * @param batiments Array of building String id
+ * 
+ * @returns Ext.Window 
+ */
+GEOR.Addons.Cadastre.onClickPrintLotsWindow = function(parcelleId, batiments) {
+    // Close previous windows if already opened
+    if (GEOR.Addons.Cadastre.printLotsWindow != null) {
+        GEOR.Addons.Cadastre.printLotsWindow.close();
+    }
+
+    GEOR.Addons.Cadastre.initPrintLotsWindow(parcelleId, batiments);
+    GEOR.Addons.Cadastre.printLotsWindow.show();
+}
+
+/**
+ * initPrintLotsWindow
+ * 
+ * @param parcelleId String
+ * @param batiments Array of building String id
+ * 
+ * @returns Ext.Window 
+ */
+GEOR.Addons.Cadastre.initPrintLotsWindow = function(parcelleId, batiments) {
+
+    // combobox building list with buildind array
+    var comboDnubat = new Ext.form.ComboBox({
+        width : 150,
+        mode : 'local',
+        forceSelection : true,
+        displayField : 'dnubat',
+        valueField : 'dnubat',
+        store : batiments,
+        value : batiments[0],
+        listeners : {
+            expand : function() {
+                this.store.removeAll();
+                this.store.loadData(batiments);
+                this.show();
+            }
+        }
+    });
+
+    // new windows
+    GEOR.Addons.Cadastre.printLotsWindow = new Ext.Window({
+        title : OpenLayers.i18n('cadastrapp.lots.title') + ' - ' + parcelleId,
+        frame : true,
+        autoScroll : true,
+        minimizable : false,
+        closable : true,
+        resizable : false,
+        draggable : true,
+        constrainHeader : true,
+        border : false,
+        width : 300,
+        defaults : {
+            autoHeight : true,
+            bodyStyle : 'padding:10px',
+            flex : 1
+        },
+        listeners : {
+            close : function(window) {
+                GEOR.Addons.Cadastre.printLotsWindow = null;
+            }
+        },
+
+        items : [ {
+            xtype : 'form',
+            id : 'lotForm',
+            height : 200,
+            labelWidth : 1,
+            autoHeight : true,
+
+            items : [ {
+                xtype : 'fieldset',
+                title : OpenLayers.i18n('cadastrapp.lots.batiments'),
+                autoHeight : true,
+
+                items : [ comboDnubat ]
+            }, {
+                xtype : 'fieldset',
+                title : OpenLayers.i18n('cadastrapp.lots.type'),
+                autoHeight : true,
+
+                items : [ {
+                    xtype : 'radio',
+                    boxLabel : OpenLayers.i18n('cadastrapp.lots.type.csv'),
+                    checked : true,
+                    name : 'exportType',
+                    id : 'radiolotscsv'
+                }, {
+                    xtype : 'radio',
+                    boxLabel : OpenLayers.i18n('cadastrapp.lots.type.pdf'),
+                    name : 'exportType',
+                    id : 'radiolotspdf'
+                } ]
+            } ]
+        } ],
+
+        buttons : [ {
+            text : OpenLayers.i18n('cadastrapp.generate'),
+            listeners : {
+                click : function(b, e) {
+
+                    // pdf by default
+                    var url = GEOR.Addons.Cadastre.cadastrappWebappUrl + 'exportLotsAsPDF';
+                    // check csv radio button value
+                    if (Ext.getCmp('radiolotscsv').getValue()) {
+                        url = GEOR.Addons.Cadastre.cadastrappWebappUrl + 'exportLotsAsCSV';
+                    }
+
+                    // create Iframe
+                    var iframe = document.createElement("iframe");
+                    iframe.setAttribute("style", "display:none;");
+
+                    // create form with attributes and request informations
+                    var form = document.createElement("form");
+                    form.setAttribute("method", "post");
+                    form.setAttribute("action", url);
+
+                    // create input with
+                    var parcelleField = document.createElement("input");
+                    parcelleField.setAttribute("type", "hidden");
+                    parcelleField.setAttribute("name", "parcelle");
+
+                    // insert values to input to set POST params
+                    parcelleField.value = parcelleId;
+
+                    // insert input to form
+                    form.appendChild(parcelleField);
+
+                    // create input with
+                    var dnubatField = document.createElement("input");
+                    dnubatField.setAttribute("type", "hidden");
+                    dnubatField.setAttribute("name", "dnubat");
+
+                    // insert values to input to set POST params
+                    dnubatField.value = comboDnubat.getRawValue();
+                    console.log("Dnubat = " + comboDnubat.getRawValue());
+                    // insert input to form
+                    form.appendChild(dnubatField);
+
+                    // insert form to iframe to only refresh hidden iframe
+                    iframe.appendChild(form);
+
+                    // insert iframe to document body
+                    document.body.appendChild(iframe);
+
+                    // submit form to launch request and get CSV
+                    form.submit();
+
+                    GEOR.Addons.Cadastre.printLotsWindow.close();
+                }
+            }
+        }, {
+            text : OpenLayers.i18n('cadastrapp.close'),
+            listeners : {
+                click : function(b, e) {
+                    GEOR.Addons.Cadastre.printLotsWindow.close();
+                }
+            }
+        } ]
+    });
+}

--- a/addons/cadastrapp/js/resultParcelle.js
+++ b/addons/cadastrapp/js/resultParcelle.js
@@ -32,6 +32,14 @@ GEOR.Addons.Cadastre.exportAsCsvButton = function() {
             },scope:this
         });
         
+        // create button to get bundle export as CSV
+        exportCsvItems.push({
+            text:OpenLayers.i18n("cadastrapp.result.csv.button.bundle"),
+            handler(){
+                return GEOR.Addons.Cadastre.exportBundle();
+            },scope:this
+        });
+        
         // create menu to set properties at this menu
         var menuCsv = new Ext.menu.Menu({
             items: exportCsvItems,
@@ -673,6 +681,49 @@ GEOR.Addons.Cadastre.exportCoOwnersAsCSV = function() {
             var params = parcellesId.join();
             GEOR.Addons.Cadastre.getCsvByPost(url, params); 
         }else {
+            Ext.Msg.alert('Status', OpenLayers.i18n('cadastrapp.result.no.selection'));
+        }
+    } else {
+        Ext.Msg.alert('Status', OpenLayers.i18n('cadastrapp.result.no.search'));
+    }  
+};
+
+/**
+ * get building list from selected plot
+ */
+GEOR.Addons.Cadastre.exportBundle = function() {
+    if (GEOR.Addons.Cadastre.result.tabs && GEOR.Addons.Cadastre.result.tabs.getActiveTab()) {
+        var selection = GEOR.Addons.Cadastre.result.tabs.getActiveTab().getSelectionModel().getSelections();
+        
+        // Only one plot
+        if (selection && selection.length == 1) {
+                       
+        	var parcelleId = selection[0].data.parcelle;
+            // Get Batiment information
+            Ext.Ajax.request({
+                method : 'GET',
+                params : {parcelle: parcelleId},
+                url : GEOR.Addons.Cadastre.cadastrappWebappUrl + "getBatimentsByParcelle",        
+                success : function(response) {
+                	
+                	var result = Ext.decode(response.responseText);          	
+                	var batiments = [];              	
+                	Ext.each(result, function(element, index) {
+                		batiments.push(element.dnubat);
+                    });
+                	if(batiments.length > 0){
+                		GEOR.Addons.Cadastre.onClickPrintLotsWindow(parcelleId, batiments);
+                	}
+                	else{
+                		Ext.Msg.alert('Status', OpenLayers.i18n('cadastrapp.lots.no.building'));
+                	}
+                },
+                failure : function(result) {
+                    alert('ERROR-');
+                }
+            });
+        }else {
+        	// Change message
             Ext.Msg.alert('Status', OpenLayers.i18n('cadastrapp.result.no.selection'));
         }
     } else {

--- a/addons/cadastrapp/manifest.json
+++ b/addons/cadastrapp/manifest.json
@@ -3,6 +3,7 @@
 	"debugjs": [
     	"js/printBordereauParcellaire.js",
     	"js/printRelevePropriete.js",
+    	"js/printLots.js",
 		"js/selectFeature.js",
 		"js/resultParcelle.js",
 		"js/resultProprietaire.js",
@@ -147,6 +148,7 @@
 			"cadastrapp.result.csv.button.parcelles" : "Plots",
 			"cadastrapp.result.csv.button.owner" : "Owners",
 			"cadastrapp.result.csv.button.coowner" : "Co-owners",
+			"cadastrapp.result.csv.button.bundle" : "Bundle",
 			"cadastrapp.result.no.search": "You need to search for a plot before",
 			"cadastrapp.result.no.selection": "You need to select plots before",
 			
@@ -336,8 +338,7 @@
 			"cadastrapp.duc.parcelle" : "Plot",
 			"cadastrapp.duc.propietaire" : "Owners",
 			"cadastrapp.duc.copropietaire" : "Co-Owners",
-			
-			
+									
 			"cadastrapp.duc.compte" : "Identifier",
 			"cadastrapp.duc.denomination": "Designation",
 			"cadastrapp.duc.nom_usage" : "Usage name",
@@ -358,6 +359,7 @@
 			"cadastrapp.duc.batiment_date" : "Date",
 			"cadastrapp.duc.batiment_revenu" : "Rent",
 			"cadastrapp.duc.batiment_descriptif" : "Description",
+			"cadastrapp.duc.batiment_bundle" : "Bundle",
 
 			"cadastrapp.duc.lettreindic" : "Index",
 			"cadastrapp.duc.contenance" : "Capacity",
@@ -406,6 +408,13 @@
 			"cadastrapp.relevepropriete.data" : "Data to extract",
 			"cadastrapp.relevepropriete.full" : "All properties",
 			"cadastrapp.relevepropriete.partial" : "Only this plot",
+			
+			"cadastrapp.lots.title" : "Bundle information",
+			"cadastrapp.lots.batiments" : "Please select one building",
+			"cadastrapp.lots.type" : "Choose output format",
+			"cadastrapp.lots.type.pdf" : "Export as PDF",
+			"cadastrapp.lots.type.csv" : "Export as CSV",
+			"cadastrapp.lots.no.building" : "No building on this plot",
 			
 			"cadastrapp.ObjectRequest.idParcelle" : "id...",
 			"cadastrapp.ObjectRequest.comptecommunal" : "id...",
@@ -516,6 +525,7 @@
 			"cadastrapp.result.csv.button.parcelles" : "Parcelle",
 			"cadastrapp.result.csv.button.owner" : "Propriétaires",
 			"cadastrapp.result.csv.button.coowner" : "Co-propriétaires",
+			"cadastrapp.result.csv.button.bundle" : "Lots",
 			"cadastrapp.result.no.search": "Veuillez sélectioner une parcelle",
 			"cadastrapp.result.no.selection": "Veuillez sélectioner une parcelle",
 			
@@ -730,6 +740,7 @@
 			"cadastrapp.duc.batiment_date" : "Date",
 			"cadastrapp.duc.batiment_revenu" : "Revenu",
 			"cadastrapp.duc.batiment_descriptif" : "Descriptif",
+			"cadastrapp.duc.batiment_bundle" : "Lots",
 			"cadastrapp.duc.lettreindic" : "Lettre indicative",
 			"cadastrapp.duc.contenance" : "Contenance",
 			"cadastrapp.duc.terrain" : "Nature de culture",
@@ -778,6 +789,13 @@
 			"cadastrapp.bordereauparcellaire.data" : "Données propriétaires",
 			"cadastrapp.bordereauparcellaire.data.without" : "Sans données nominatives",
 			"cadastrapp.bordereauparcellaire.data.with" : "Avec données nominatives",
+			
+			"cadastrapp.lots.title" : "Lots",
+			"cadastrapp.lots.batiments" : "Choisissez un batiment",
+			"cadastrapp.lots.type" : "Choissiez un format de fichier",
+			"cadastrapp.lots.type.pdf" : "PDF",
+			"cadastrapp.lots.type.csv" : "CSV",
+			"cadastrapp.lots.no.building" : "Pas de lots sur cette parcelle",
 			
 			"cadastrapp.ObjectRequest.idParcelle" : "id...",
 			"cadastrapp.ObjectRequest.comptecommunal" : "id...",

--- a/cadastrapp/jsbuild/main.cfg
+++ b/cadastrapp/jsbuild/main.cfg
@@ -2,22 +2,24 @@
 root = ../../addons/cadastrapp/js
 
 include =
-    cadastrappUtil.js
-    componentUtils.js
-    detailUniteCadastrale.js
-    detailUniteFonciere.js
-    external/fileUploadField.js
-    habitationDetails.js
-    informationsRequest.js
-    infoBulle.js
-    main.js
-    menu.js
-    printBordereauParcellaire.js
-    printRelevePropriete.js
-    resultParcelle.js
-    resultProprietaire.js
-    searchCoPropriete.js
-    searchParcelleByOwner.js
-    searchParcelleByRef.js
-    searchUtils.js
-    selectFeature.js
+ 	printBordereauParcellaire.js
+	printRelevePropriete.js	
+	printLots.js	
+	selectFeature.js	
+	resultParcelle.js	
+	resultProprietaire.js	
+	searchUtils.js	
+	componentUtils.js	
+	searchParcelleByOwner.js	
+	searchParcelleByRef.js	
+	searchCoPropriete.js	
+	informationsRequest.js	
+	detailUniteFonciere.js	
+	habitationDetails.js	
+	detailUniteCadastrale.js	
+	infoBulle.js	
+	menu.js	
+	main.js	
+	cadastrappUtil.js	
+	external/fileUploadField.js	
+    

--- a/cadastrapp/pom.xml
+++ b/cadastrapp/pom.xml
@@ -640,7 +640,7 @@
               <projectUrl>http://www.georchestra.org/</projectUrl>
               <projectOrganization>geOrchestra</projectOrganization>
               <maintainerName>Pierre Jego</maintainerName>
-              <maintainerEmail>pierre.jego@gfi.fr</maintainerEmail>
+              <maintainerEmail>pierre.jego@jdev.fr</maintainerEmail>
               <excludeAllArtifacts>true</excludeAllArtifacts>
               <snapshotRevisionFile>${project.build.directory}</snapshotRevisionFile>
             </configuration>

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/helper/BatimentHelper.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/helper/BatimentHelper.java
@@ -1,0 +1,45 @@
+package org.georchestra.cadastrapp.helper;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.core.HttpHeaders;
+
+import org.georchestra.cadastrapp.service.CadController;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public final class BatimentHelper extends CadController {
+
+	static final Logger logger = LoggerFactory.getLogger(BatimentHelper.class);
+
+	/**
+	 * 
+	 * getBuildings
+	 * 
+	 * @param String parcelle / Id Parcelle exemple : 2014630103000AP0025
+	 * @param HttpHeaders headers
+	 * 
+	 * @return List<Map<String, Object>>  get all building from given plot
+	 */
+	public List<Map<String, Object>> getBuildings(String parcelle, HttpHeaders headers ){
+		
+		logger.debug("infoOngletBatiment - parcelle : " + parcelle);
+		
+		StringBuilder queryBuilder = new StringBuilder();
+		
+		queryBuilder.append("select distinct pb.dnubat from ");
+		queryBuilder.append(databaseSchema);
+		queryBuilder.append(".proprietebatie pb ");
+		queryBuilder.append(" where pb.parcelle = ? ");
+		queryBuilder.append(addAuthorizationFiltering(headers, "pb."));
+		queryBuilder.append(" ORDER BY pb.dnubat");
+		
+		JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+		return jdbcTemplate.queryForList(queryBuilder.toString(), parcelle);		
+	}
+}

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/helper/ProprieteHelper.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/helper/ProprieteHelper.java
@@ -550,8 +550,7 @@ public final class ProprieteHelper extends CadController {
 		queryBuilderPLot.append(" where p.parcelle = ? ");
 
 		JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-		List<Map<String, Object>> parcelleInformations = jdbcTemplate.queryForList(queryBuilderPLot.toString(),
-				parcelle);
+		List<Map<String, Object>> parcelleInformations = jdbcTemplate.queryForList(queryBuilderPLot.toString(), parcelle);
 
 		// Use loop because queryForObject will throw an exception if adress is empty.
 		// Even if no adresse export should be done.
@@ -569,7 +568,9 @@ public final class ProprieteHelper extends CadController {
 
 			lot.setLotId((String) lotInformation.get("dnulot"));
 			lot.setNumerateur((String) lotInformation.get("dnumql"));
-			nbParts = nbParts + Integer.parseInt(lot.getNumerateur());
+			if(lot.getNumerateur().length() >0){
+				nbParts = nbParts + Integer.parseInt(lot.getNumerateur());
+			}
 			lot.setDenominateur((String) lotInformation.get("ddenql"));
 
 			ProprieteBatie pb = new ProprieteBatie();

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/helper/ProprieteHelper.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/helper/ProprieteHelper.java
@@ -25,8 +25,18 @@ public final class ProprieteHelper extends CadController {
 
 	static final Logger logger = LoggerFactory.getLogger(ProprieteHelper.class);
 
+	/**
+	 * getProprieteBatieInformation
+	 * 
+	 * @param idCompteCommunal  String owner id
+	 * @param idParcelle String plots id
+	 * @return ProprietesBaties object with information coming from database
+	 * 			
+	 */
 	public ProprietesBaties getProprieteBatieInformation(String idCompteCommunal, String idParcelle) {
 
+		logger.debug("Get developed property information ");
+		
 		ProprietesBaties pbs = new ProprietesBaties();
 
 		// Information sur les proprietés baties
@@ -51,7 +61,6 @@ public final class ProprieteHelper extends CadController {
 		// Add map of invar to maker sure not to add two times taxable income
 		List<String> invarTICount = new ArrayList<String>();
 
-		logger.debug("Get developed property information ");
 		JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
 		List<Map<String, Object>> proprietesBatiesResult = jdbcTemplate.queryForList(queryBuilderProprieteBatie.toString(), idCompteCommunal);
 
@@ -169,8 +178,18 @@ public final class ProprieteHelper extends CadController {
 		return pbs;
 	}
 
+	/**
+	 * getProprieteNonBatieInformation
+	 * 
+	 * @param idCompteCommunal  String owner id
+	 * @param idParcelle String plots id
+	 * @return ProprietesBaties object with information coming from database
+	 * 			
+	 */
 	public ProprietesNonBaties getProprieteNonBatieInformation(String idCompteCommunal, String idParcelle) {
 
+		logger.debug("Get undeveloped property information ");
+		
 		ProprietesNonBaties pnbs = new ProprietesNonBaties();
 
 		// Information sur les proprietés non baties
@@ -198,7 +217,6 @@ public final class ProprieteHelper extends CadController {
 		queryBuilderProprieteNonBatie.append(".proprietenonbatie pnb ");
 		queryBuilderProprieteNonBatie.append(" where pnb.comptecommunal = ? ORDER BY ccosec, dnupla");
 
-		logger.debug("Get undeveloped property information ");
 		JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
 		List<Map<String, Object>> proprietesNonBatiesResult = jdbcTemplate.queryForList(queryBuilderProprieteNonBatie.toString(), idCompteCommunal);
 
@@ -324,10 +342,12 @@ public final class ProprieteHelper extends CadController {
 		return pnbs;
 	}
 
-	// TODO try changing this,
-	// making a request on each loop might not the best solution,
-	// but it can have more than one lot for one invar
-	// Make sure an index exist on id_local
+
+	/**
+	 *  getLotInformation 
+	 * @param idLocal String local id from invar
+	 * @return List<Lot> bundle number and distribution in this bundle
+	 */
 	public List<Lot> getLotInformation(String idLocal) {
 
 		StringBuilder queryBuilderLots = new StringBuilder();
@@ -342,7 +362,7 @@ public final class ProprieteHelper extends CadController {
 
 		List<Lot> proprieteBatieLot = new ArrayList<Lot>();
 		for (Map<String, Object> propBatLot : proprietesBatiesLots) {
-			// Create lot and add information
+			// Create bundle and add information
 			Lot lot = new Lot();
 			lot.setLotId((String) propBatLot.get(CadastrappConstants.PB_LOT_ID));
 			lot.setDenominateur((String) propBatLot.get(CadastrappConstants.PB_LOT_DENOMINATEUR));
@@ -352,7 +372,7 @@ public final class ProprieteHelper extends CadController {
 				logger.debug("Lot : " + lot);
 			}
 
-			// add lot to list
+			// add bundle to list
 			proprieteBatieLot.add(lot);
 		}
 		return proprieteBatieLot;

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/helper/ProprieteHelper.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/helper/ProprieteHelper.java
@@ -7,11 +7,14 @@ import java.math.BigDecimal;
 
 import org.georchestra.cadastrapp.model.pdf.Imposition;
 import org.georchestra.cadastrapp.model.pdf.ImpositionNonBatie;
+import org.georchestra.cadastrapp.model.pdf.InformationLots;
 import org.georchestra.cadastrapp.model.pdf.Lot;
+import org.georchestra.cadastrapp.model.pdf.Proprietaire;
 import org.georchestra.cadastrapp.model.pdf.ProprieteBatie;
 import org.georchestra.cadastrapp.model.pdf.ProprieteNonBatie;
 import org.georchestra.cadastrapp.model.pdf.ProprietesBaties;
 import org.georchestra.cadastrapp.model.pdf.ProprietesNonBaties;
+import org.georchestra.cadastrapp.configuration.CadastrappPlaceHolder;
 import org.georchestra.cadastrapp.model.pdf.Exoneration;
 import org.georchestra.cadastrapp.service.CadController;
 import org.georchestra.cadastrapp.service.constants.CadastrappConstants;
@@ -28,15 +31,17 @@ public final class ProprieteHelper extends CadController {
 	/**
 	 * getProprieteBatieInformation
 	 * 
-	 * @param idCompteCommunal  String owner id
-	 * @param idParcelle String plots id
+	 * @param idCompteCommunal
+	 *            String owner id
+	 * @param idParcelle
+	 *            String plots id
 	 * @return ProprietesBaties object with information coming from database
-	 * 			
+	 * 
 	 */
 	public ProprietesBaties getProprieteBatieInformation(String idCompteCommunal, String idParcelle) {
 
 		logger.debug("Get developed property information ");
-		
+
 		ProprietesBaties pbs = new ProprietesBaties();
 
 		// Information sur les proprietés baties
@@ -52,7 +57,8 @@ public final class ProprieteHelper extends CadController {
 
 		StringBuilder queryBuilderProprieteBatie = new StringBuilder();
 
-		queryBuilderProprieteBatie.append("select distinct id_local, ccopre, ccosec, dnupla, COALESCE(natvoi,'')||' '||COALESCE(dvoilib,'') as voie, ccoriv, dnubat, descr, dniv, dpor, invar, ccoaff, ccoeva, cconlc, dcapec, ccolloc, gnextl, jandeb, janimp, gtauom, pexb, rcexba2, rcbaia_com, rcbaia_dep, rcbaia_gp, rcbaia_tse, revcad, jdatat, parcelle, ccocac ");
+		queryBuilderProprieteBatie.append(
+				"select distinct id_local, ccopre, ccosec, dnupla, COALESCE(natvoi,'')||' '||COALESCE(dvoilib,'') as voie, ccoriv, dnubat, descr, dniv, dpor, invar, ccoaff, ccoeva, cconlc, dcapec, ccolloc, gnextl, jandeb, janimp, gtauom, pexb, rcexba2, rcbaia_com, rcbaia_dep, rcbaia_gp, rcbaia_tse, revcad, jdatat, parcelle, ccocac ");
 		queryBuilderProprieteBatie.append("from ");
 		queryBuilderProprieteBatie.append(databaseSchema);
 		queryBuilderProprieteBatie.append(".proprietebatie pb ");
@@ -62,17 +68,21 @@ public final class ProprieteHelper extends CadController {
 		List<String> invarTICount = new ArrayList<String>();
 
 		JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-		List<Map<String, Object>> proprietesBatiesResult = jdbcTemplate.queryForList(queryBuilderProprieteBatie.toString(), idCompteCommunal);
+		List<Map<String, Object>> proprietesBatiesResult = jdbcTemplate
+				.queryForList(queryBuilderProprieteBatie.toString(), idCompteCommunal);
 
 		for (Map<String, Object> propBat : proprietesBatiesResult) {
-			if (idParcelle == null || idParcelle.isEmpty() || idParcelle.equals((String) propBat.get(CadastrappConstants.PARC_ID))) {
+			if (idParcelle == null || idParcelle.isEmpty()
+					|| idParcelle.equals((String) propBat.get(CadastrappConstants.PARC_ID))) {
 				ProprieteBatie proprieteBatie = new ProprieteBatie();
 
 				if (logger.isDebugEnabled()) {
-					logger.debug("Get developed property invar : " + (String) propBat.get(CadastrappConstants.PB_NUM_INVARIANT));
+					logger.debug("Get developed property invar : "
+							+ (String) propBat.get(CadastrappConstants.PB_NUM_INVARIANT));
 				}
 
-				String proprieteId = (String) propBat.get(CadastrappConstants.PB_NUM_INVARIANT);// N° invar
+				String proprieteId = (String) propBat.get(CadastrappConstants.PB_NUM_INVARIANT);// N°
+																								// invar
 				proprieteBatie.setInvar(proprieteId);
 				String idLocal = (String) propBat.get(CadastrappConstants.PB_ID_LOCAL);
 
@@ -80,21 +90,34 @@ public final class ProprieteHelper extends CadController {
 				proprieteBatie.setLots(getLotInformation(idLocal));
 
 				proprieteBatie.setCcoaff((String) propBat.get(CadastrappConstants.PB_AFFECTATION_PEV)); // AF
-				proprieteBatie.setCcoeva((String) propBat.get(CadastrappConstants.PB_CODE_EVAL)); // M EVAL
-				proprieteBatie.setCconlc((String) propBat.get(CadastrappConstants.PB_NATURE_LOCAL)); // NAT LOC
-				proprieteBatie.setCcocac((String) propBat.get(CadastrappConstants.PB_NATURE_LOCAL_PRO)); // NAT LOC PRO
-				proprieteBatie.setCcopre((String) propBat.get(CadastrappConstants.PREFIX_SECTION)); // N°Section part1
-				proprieteBatie.setCcoriv((String) propBat.get(CadastrappConstants.CODE_RIVOLI_VOIE)); // code rivoli
-				proprieteBatie.setCcosec((String) propBat.get(CadastrappConstants.LETTRE_SECTION)); // N°Section partt2
+				proprieteBatie.setCcoeva((String) propBat.get(CadastrappConstants.PB_CODE_EVAL)); // M
+																									// EVAL
+				proprieteBatie.setCconlc((String) propBat.get(CadastrappConstants.PB_NATURE_LOCAL)); // NAT
+																										// LOC
+				proprieteBatie.setCcocac((String) propBat.get(CadastrappConstants.PB_NATURE_LOCAL_PRO)); // NAT
+																											// LOC
+																											// PRO
+				proprieteBatie.setCcopre((String) propBat.get(CadastrappConstants.PREFIX_SECTION)); // N°Section
+																									// part1
+				proprieteBatie.setCcoriv((String) propBat.get(CadastrappConstants.CODE_RIVOLI_VOIE)); // code
+																										// rivoli
+				proprieteBatie.setCcosec((String) propBat.get(CadastrappConstants.LETTRE_SECTION)); // N°Section
+																									// partt2
 				proprieteBatie.setDcapec((String) propBat.get(CadastrappConstants.PB_CATEGORIE)); // Cat
 				proprieteBatie.setDescr((String) propBat.get(CadastrappConstants.PB_NUM_ENTREE)); // Ent
 				proprieteBatie.setDniv((String) propBat.get(CadastrappConstants.PB_NIV_ETAGE)); // Niv
 				proprieteBatie.setDnubat((String) propBat.get(CadastrappConstants.PB_LETTRE_BAT)); // Bat
-				proprieteBatie.setDnupla((String) propBat.get(CadastrappConstants.NUM_PLAN)); // N° plan
-				proprieteBatie.setDpor((String) propBat.get(CadastrappConstants.PB_NUM_PORTE_LOCAL)); // N° porte
-				proprieteBatie.setRevcad(propBat.get(CadastrappConstants.PB_VAL_LOCAT_TOTAL) == null ? "" : propBat.get(CadastrappConstants.PB_VAL_LOCAT_TOTAL).toString()); // Revenu cadastral
+				proprieteBatie.setDnupla((String) propBat.get(CadastrappConstants.NUM_PLAN)); // N°
+																								// plan
+				proprieteBatie.setDpor((String) propBat.get(CadastrappConstants.PB_NUM_PORTE_LOCAL)); // N°
+																										// porte
+				proprieteBatie.setRevcad(propBat.get(CadastrappConstants.PB_VAL_LOCAT_TOTAL) == null ? ""
+						: propBat.get(CadastrappConstants.PB_VAL_LOCAT_TOTAL).toString()); // Revenu
+																							// cadastral
 				proprieteBatie.setDvoilib((String) propBat.get(CadastrappConstants.ADRESSE)); // Adresse
-				proprieteBatie.setGtauom(propBat.get(CadastrappConstants.PB_MONTANT_TIEOM) == null ? "" : propBat.get(CadastrappConstants.PB_MONTANT_TIEOM).toString()); // tx OM
+				proprieteBatie.setGtauom(propBat.get(CadastrappConstants.PB_MONTANT_TIEOM) == null ? ""
+						: propBat.get(CadastrappConstants.PB_MONTANT_TIEOM).toString()); // tx
+																							// OM
 				if (CadastrappConstants.MUTATION != null) {
 					// Date is store in database like jj/mm/yyyy
 					String[] parts = propBat.get(CadastrappConstants.MUTATION).toString().split("/");
@@ -107,11 +130,18 @@ public final class ProprieteHelper extends CadController {
 				Exoneration proprieteBatieExoneration = new Exoneration();
 
 				proprieteBatieExoneration.setCcolloc((String) propBat.get(CadastrappConstants.PB_CODE_COLL_EXO)); // COLL
-				proprieteBatieExoneration.setGnextl((String) propBat.get(CadastrappConstants.PB_NATURE_EXO)); // Nat Exo
-				proprieteBatieExoneration.setJandeb((String) propBat.get(CadastrappConstants.PB_ANNEE_DEB_EXO)); // An Deb
-				proprieteBatieExoneration.setJanimp((String) propBat.get(CadastrappConstants.PB_ANNEE_RETOUR_IMPOSITION)); // An Ret
-				proprieteBatieExoneration.setFcexn(propBat.get(CadastrappConstants.PB_FRACTION_EXO) == null ? "" : propBat.get(CadastrappConstants.PB_FRACTION_EXO).toString()); // Fraction Exo
-				proprieteBatieExoneration.setPexb(propBat.get(CadastrappConstants.PB_TAUX_EXO_ACCORDEE) == null ? "" : propBat.get(CadastrappConstants.PB_TAUX_EXO_ACCORDEE).toString());// Exo
+				proprieteBatieExoneration.setGnextl((String) propBat.get(CadastrappConstants.PB_NATURE_EXO)); // Nat
+																												// Exo
+				proprieteBatieExoneration.setJandeb((String) propBat.get(CadastrappConstants.PB_ANNEE_DEB_EXO)); // An
+																													// Deb
+				proprieteBatieExoneration
+						.setJanimp((String) propBat.get(CadastrappConstants.PB_ANNEE_RETOUR_IMPOSITION)); // An
+																											// Ret
+				proprieteBatieExoneration.setFcexn(propBat.get(CadastrappConstants.PB_FRACTION_EXO) == null ? ""
+						: propBat.get(CadastrappConstants.PB_FRACTION_EXO).toString()); // Fraction
+																						// Exo
+				proprieteBatieExoneration.setPexb(propBat.get(CadastrappConstants.PB_TAUX_EXO_ACCORDEE) == null ? ""
+						: propBat.get(CadastrappConstants.PB_TAUX_EXO_ACCORDEE).toString());// Exo
 
 				proprieteBatieExonerations.add(proprieteBatieExoneration);
 				proprieteBatie.setExonerations(proprieteBatieExonerations);
@@ -119,15 +149,21 @@ public final class ProprieteHelper extends CadController {
 				// Add exoneration depending on type
 				String exoneration = (String) propBat.get(CadastrappConstants.PB_CODE_COLL_EXO);
 				if (CadastrappConstants.CODE_COLL_EXO_TC.equals(exoneration)) {
-					pbCommuneRevenuExonere = pbCommuneRevenuExonere + ((BigDecimal) propBat.get(CadastrappConstants.PB_FRACTION_EXO)).floatValue();
-					pbDepartementRevenuExonere = pbDepartementRevenuExonere + ((BigDecimal) propBat.get(CadastrappConstants.PB_FRACTION_EXO)).floatValue();
-					pbGroupementCommuneRevenuExonere = pbGroupementCommuneRevenuExonere + ((BigDecimal) propBat.get(CadastrappConstants.PB_FRACTION_EXO)).floatValue();
+					pbCommuneRevenuExonere = pbCommuneRevenuExonere
+							+ ((BigDecimal) propBat.get(CadastrappConstants.PB_FRACTION_EXO)).floatValue();
+					pbDepartementRevenuExonere = pbDepartementRevenuExonere
+							+ ((BigDecimal) propBat.get(CadastrappConstants.PB_FRACTION_EXO)).floatValue();
+					pbGroupementCommuneRevenuExonere = pbGroupementCommuneRevenuExonere
+							+ ((BigDecimal) propBat.get(CadastrappConstants.PB_FRACTION_EXO)).floatValue();
 				} else if (CadastrappConstants.CODE_COLL_EXO_C.equals(exoneration)) {
-					pbCommuneRevenuExonere = pbCommuneRevenuExonere + ((BigDecimal) propBat.get(CadastrappConstants.PB_FRACTION_EXO)).floatValue();
+					pbCommuneRevenuExonere = pbCommuneRevenuExonere
+							+ ((BigDecimal) propBat.get(CadastrappConstants.PB_FRACTION_EXO)).floatValue();
 				} else if (CadastrappConstants.CODE_COLL_EXO_GC.equals(exoneration)) {
-					pbGroupementCommuneRevenuExonere = pbGroupementCommuneRevenuExonere + ((BigDecimal) propBat.get(CadastrappConstants.PB_FRACTION_EXO)).floatValue();
+					pbGroupementCommuneRevenuExonere = pbGroupementCommuneRevenuExonere
+							+ ((BigDecimal) propBat.get(CadastrappConstants.PB_FRACTION_EXO)).floatValue();
 				} else if (CadastrappConstants.CODE_COLL_EXO_D.equals(exoneration)) {
-					pbDepartementRevenuExonere = pbDepartementRevenuExonere + ((BigDecimal) propBat.get(CadastrappConstants.PB_FRACTION_EXO)).floatValue();
+					pbDepartementRevenuExonere = pbDepartementRevenuExonere
+							+ ((BigDecimal) propBat.get(CadastrappConstants.PB_FRACTION_EXO)).floatValue();
 				} else if (CadastrappConstants.CODE_COLL_EXO_A.equals(exoneration)) {
 					logger.debug("Exoneration on additional taxes");
 				}
@@ -136,10 +172,14 @@ public final class ProprieteHelper extends CadController {
 				if (!invarTICount.contains(proprieteId)) {
 					invarTICount.add(proprieteId);
 
-					float communeRevenuImposable = propBat.get("rcbaia_com") == null ? 0 : ((BigDecimal) propBat.get("rcbaia_com")).floatValue();
-					float groupementCommuneRevenuImposable = propBat.get("rcbaia_gp") == null ? 0 : ((BigDecimal) propBat.get("rcbaia_gp")).floatValue();
-					float departementRevenuImposable = propBat.get("rcbaia_dep") == null ? 0 : ((BigDecimal) propBat.get("rcbaia_dep")).floatValue();
-					float tseRevenuImposable = propBat.get("rcbaia_tse") == null ? 0 : ((BigDecimal) propBat.get("rcbaia_tse")).floatValue();
+					float communeRevenuImposable = propBat.get("rcbaia_com") == null ? 0
+							: ((BigDecimal) propBat.get("rcbaia_com")).floatValue();
+					float groupementCommuneRevenuImposable = propBat.get("rcbaia_gp") == null ? 0
+							: ((BigDecimal) propBat.get("rcbaia_gp")).floatValue();
+					float departementRevenuImposable = propBat.get("rcbaia_dep") == null ? 0
+							: ((BigDecimal) propBat.get("rcbaia_dep")).floatValue();
+					float tseRevenuImposable = propBat.get("rcbaia_tse") == null ? 0
+							: ((BigDecimal) propBat.get("rcbaia_tse")).floatValue();
 
 					Imposition pbImposition = new Imposition();
 
@@ -150,16 +190,19 @@ public final class ProprieteHelper extends CadController {
 
 					proprieteBatie.setImposition(pbImposition);
 
-					pbRevenuImposable = pbRevenuImposable + (propBat.get(CadastrappConstants.PB_VAL_LOCAT_TOTAL) == null ? 0 : ((BigDecimal) propBat.get(CadastrappConstants.PB_VAL_LOCAT_TOTAL)).floatValue());
+					pbRevenuImposable = pbRevenuImposable + (propBat.get(CadastrappConstants.PB_VAL_LOCAT_TOTAL) == null
+							? 0 : ((BigDecimal) propBat.get(CadastrappConstants.PB_VAL_LOCAT_TOTAL)).floatValue());
 					pbCommuneRevenuImposable = pbCommuneRevenuImposable + communeRevenuImposable;
 					pbDepartementRevenuImposable = pbDepartementRevenuImposable + departementRevenuImposable;
-					pbGroupementCommuneRevenuImposable = pbGroupementCommuneRevenuImposable + groupementCommuneRevenuImposable;
+					pbGroupementCommuneRevenuImposable = pbGroupementCommuneRevenuImposable
+							+ groupementCommuneRevenuImposable;
 				}
 
 				proprietesBaties.add(proprieteBatie);
 			}
 		}
-		// ajout la liste des propriete baties uniquement si il y en a au moins une
+		// ajout la liste des propriete baties uniquement si il y en a au moins
+		// une
 		if (!proprietesBaties.isEmpty()) {
 
 			// Init imposition batie
@@ -181,15 +224,17 @@ public final class ProprieteHelper extends CadController {
 	/**
 	 * getProprieteNonBatieInformation
 	 * 
-	 * @param idCompteCommunal  String owner id
-	 * @param idParcelle String plots id
+	 * @param idCompteCommunal
+	 *            String owner id
+	 * @param idParcelle
+	 *            String plots id
 	 * @return ProprietesBaties object with information coming from database
-	 * 			
+	 * 
 	 */
 	public ProprietesNonBaties getProprieteNonBatieInformation(String idCompteCommunal, String idParcelle) {
 
 		logger.debug("Get undeveloped property information ");
-		
+
 		ProprietesNonBaties pnbs = new ProprietesNonBaties();
 
 		// Information sur les proprietés non baties
@@ -207,10 +252,14 @@ public final class ProprieteHelper extends CadController {
 
 		StringBuilder queryBuilderProprieteNonBatie = new StringBuilder();
 
-		queryBuilderProprieteNonBatie.append("select distinct pnb.id_local, pnb.cgocommune, pnb.ccopre, pnb.ccosec, pnb.dnupla, ");
-		queryBuilderProprieteNonBatie.append("COALESCE(pnb.natvoi,'')||' '||COALESCE(pnb.dvoilib,'') as voie, pnb.ccoriv, pnb.dparpi, ");
-		queryBuilderProprieteNonBatie.append("pnb.ccostn, pnb.ccosub, pnb.cgrnum, pnb.dsgrpf, pnb.dclssf, pnb.cnatsp, pnb.dcntsf, pnb.drcsuba, ");
-		queryBuilderProprieteNonBatie.append("pnb.dnulot, pnb.dreflf, pnb.majposa, pnb.bisufad_com, pnb.bisufad_dep, pnb.bisufad_gp, pnb.gparnf, ");
+		queryBuilderProprieteNonBatie
+				.append("select distinct pnb.id_local, pnb.cgocommune, pnb.ccopre, pnb.ccosec, pnb.dnupla, ");
+		queryBuilderProprieteNonBatie
+				.append("COALESCE(pnb.natvoi,'')||' '||COALESCE(pnb.dvoilib,'') as voie, pnb.ccoriv, pnb.dparpi, ");
+		queryBuilderProprieteNonBatie.append(
+				"pnb.ccostn, pnb.ccosub, pnb.cgrnum, pnb.dsgrpf, pnb.dclssf, pnb.cnatsp, pnb.dcntsf, pnb.drcsuba, ");
+		queryBuilderProprieteNonBatie.append(
+				"pnb.dnulot, pnb.dreflf, pnb.majposa, pnb.bisufad_com, pnb.bisufad_dep, pnb.bisufad_gp, pnb.gparnf, ");
 		queryBuilderProprieteNonBatie.append("pnb.jdatat, pnb.parcelle ");
 		queryBuilderProprieteNonBatie.append("from ");
 		queryBuilderProprieteNonBatie.append(databaseSchema);
@@ -218,10 +267,12 @@ public final class ProprieteHelper extends CadController {
 		queryBuilderProprieteNonBatie.append(" where pnb.comptecommunal = ? ORDER BY ccosec, dnupla");
 
 		JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-		List<Map<String, Object>> proprietesNonBatiesResult = jdbcTemplate.queryForList(queryBuilderProprieteNonBatie.toString(), idCompteCommunal);
+		List<Map<String, Object>> proprietesNonBatiesResult = jdbcTemplate
+				.queryForList(queryBuilderProprieteNonBatie.toString(), idCompteCommunal);
 
 		for (Map<String, Object> propNonBat : proprietesNonBatiesResult) {
-			if (idParcelle == null || idParcelle.isEmpty() || idParcelle.equals((String) propNonBat.get(CadastrappConstants.PARC_ID))) {
+			if (idParcelle == null || idParcelle.isEmpty()
+					|| idParcelle.equals((String) propNonBat.get(CadastrappConstants.PARC_ID))) {
 				String proprieteNbId = (String) propNonBat.get("id_local");
 
 				if (logger.isDebugEnabled()) {
@@ -230,34 +281,49 @@ public final class ProprieteHelper extends CadController {
 
 				// Get exonerations for this PNB
 				StringBuilder queryBuilderProprieteNonBatieExo = new StringBuilder();
-				queryBuilderProprieteNonBatieExo.append("SELECT pnbsufexo.id_local, pnbsufexo.ccolloc, pnbsufexo.gnexts, pnbsufexo.jfinex, ");
+				queryBuilderProprieteNonBatieExo
+						.append("SELECT pnbsufexo.id_local, pnbsufexo.ccolloc, pnbsufexo.gnexts, pnbsufexo.jfinex, ");
 				queryBuilderProprieteNonBatieExo.append("pnbsufexo.rcexnba, pnbsufexo.pexn ");
 				queryBuilderProprieteNonBatieExo.append("from ");
 				queryBuilderProprieteNonBatieExo.append(databaseSchema);
 				queryBuilderProprieteNonBatieExo.append(".proprietenonbatiesufexo pnbsufexo ");
-				queryBuilderProprieteNonBatieExo.append(" where pnbsufexo.cgocommune = ? and pnbsufexo.id_local = ? ORDER BY ccolloc");
-				List<Map<String, Object>> proprieteNonBatieExonerationsResult = jdbcTemplate.queryForList(queryBuilderProprieteNonBatieExo.toString(), (String) propNonBat.get("cgocommune"), proprieteNbId);
+				queryBuilderProprieteNonBatieExo
+						.append(" where pnbsufexo.cgocommune = ? and pnbsufexo.id_local = ? ORDER BY ccolloc");
+				List<Map<String, Object>> proprieteNonBatieExonerationsResult = jdbcTemplate.queryForList(
+						queryBuilderProprieteNonBatieExo.toString(), (String) propNonBat.get("cgocommune"),
+						proprieteNbId);
 
 				List<Exoneration> proprieteNonBatieExonerations = new ArrayList<Exoneration>();
 				for (Map<String, Object> propNonBatExo : proprieteNonBatieExonerationsResult) {
 					Exoneration proprieteNonBatieExoneration = new Exoneration();
 
-					proprieteNonBatieExoneration.setCcolloc((String) propNonBatExo.get(CadastrappConstants.PNB_CODE_COLL_EXO));
-					proprieteNonBatieExoneration.setGnextl((String) propNonBatExo.get(CadastrappConstants.PNB_NATURE_EXO));
-					proprieteNonBatieExoneration.setJanimp((String) propNonBatExo.get(CadastrappConstants.PNB_ANNEE_RETOUR_IMPOSITION));
-					proprieteNonBatieExoneration.setFcexn(propNonBatExo.get(CadastrappConstants.PNB_FRACTION_RC_EXO) == null ? "" : propNonBatExo.get(CadastrappConstants.PNB_FRACTION_RC_EXO).toString());
-					proprieteNonBatieExoneration.setPexb(propNonBatExo.get(CadastrappConstants.PNB_POURCENTAGE_EXO) == null ? "" : propNonBatExo.get(CadastrappConstants.PNB_POURCENTAGE_EXO).toString());// à
+					proprieteNonBatieExoneration
+							.setCcolloc((String) propNonBatExo.get(CadastrappConstants.PNB_CODE_COLL_EXO));
+					proprieteNonBatieExoneration
+							.setGnextl((String) propNonBatExo.get(CadastrappConstants.PNB_NATURE_EXO));
+					proprieteNonBatieExoneration
+							.setJanimp((String) propNonBatExo.get(CadastrappConstants.PNB_ANNEE_RETOUR_IMPOSITION));
+					proprieteNonBatieExoneration
+							.setFcexn(propNonBatExo.get(CadastrappConstants.PNB_FRACTION_RC_EXO) == null ? ""
+									: propNonBatExo.get(CadastrappConstants.PNB_FRACTION_RC_EXO).toString());
+					proprieteNonBatieExoneration
+							.setPexb(propNonBatExo.get(CadastrappConstants.PNB_POURCENTAGE_EXO) == null ? ""
+									: propNonBatExo.get(CadastrappConstants.PNB_POURCENTAGE_EXO).toString());// à
 
 					proprieteNonBatieExonerations.add(proprieteNonBatieExoneration);
 
 					// "TC";"toutes les collectivités"
-					// "R";"Région => l'exonération porte sur la seule part régionale"
+					// "R";"Région => l'exonération porte sur la seule part
+					// régionale"
 					// "GC";"Groupement de communes"
-					// "D";"Département => l'exonération porte sur la seule part départementale"
-					// "C";"Commune => l'exonération porte sur la seule part communale"
+					// "D";"Département => l'exonération porte sur la seule part
+					// départementale"
+					// "C";"Commune => l'exonération porte sur la seule part
+					// communale"
 					// "A";"l'exonération porte sur la taxe additionnelle"
 					String exonerationType = (String) propNonBatExo.get(CadastrappConstants.PNB_CODE_COLL_EXO);
-					float exonerationValue = (propNonBatExo.get("rcexnba") == null ? 0 : ((BigDecimal) propNonBatExo.get("rcexnba")).floatValue());
+					float exonerationValue = (propNonBatExo.get("rcexnba") == null ? 0
+							: ((BigDecimal) propNonBatExo.get("rcexnba")).floatValue());
 					if (CadastrappConstants.CODE_COLL_EXO_TC.equals(exonerationType)) {
 						pnbCommuneRevenuExonere = pnbCommuneRevenuExonere + exonerationValue;
 						pnbDepartementRevenuExonere = pnbDepartementRevenuExonere + exonerationValue;
@@ -300,19 +366,26 @@ public final class ProprieteHelper extends CadController {
 					}
 				}
 
-				int surface = (Integer) propNonBat.get(CadastrappConstants.PNB_CONTENANCE_CA) == null ? 0 : (Integer) propNonBat.get(CadastrappConstants.PNB_CONTENANCE_CA);
+				int surface = (Integer) propNonBat.get(CadastrappConstants.PNB_CONTENANCE_CA) == null ? 0
+						: (Integer) propNonBat.get(CadastrappConstants.PNB_CONTENANCE_CA);
 				proprieteNonBatie.setDcntsf(surface);
 
-				float revenu = propNonBat.get(CadastrappConstants.PNB_REVENU_CADASTRAL) == null ? 0 : ((BigDecimal) propNonBat.get(CadastrappConstants.PNB_REVENU_CADASTRAL)).floatValue();
+				float revenu = propNonBat.get(CadastrappConstants.PNB_REVENU_CADASTRAL) == null ? 0
+						: ((BigDecimal) propNonBat.get(CadastrappConstants.PNB_REVENU_CADASTRAL)).floatValue();
 				proprieteNonBatie.setDrcsuba(revenu);
 
 				pnbRevenuImposable = pnbRevenuImposable + revenu;
 
-				pnbCommuneRevenuImposable = pnbCommuneRevenuImposable + (propNonBat.get("bisufad_com") == null ? 0 : ((BigDecimal) propNonBat.get("bisufad_com")).floatValue());
-				pnbDepartementRevenuImposable = pnbDepartementRevenuImposable + (propNonBat.get("bisufad_dep") == null ? 0 : ((BigDecimal) propNonBat.get("bisufad_dep")).floatValue());
-				pnbGroupementCommuneRevenuImposable = pnbGroupementCommuneRevenuImposable + (propNonBat.get("bisufad_gp") == null ? 0 : ((BigDecimal) propNonBat.get("bisufad_gp")).floatValue());
+				pnbCommuneRevenuImposable = pnbCommuneRevenuImposable + (propNonBat.get("bisufad_com") == null ? 0
+						: ((BigDecimal) propNonBat.get("bisufad_com")).floatValue());
+				pnbDepartementRevenuImposable = pnbDepartementRevenuImposable + (propNonBat.get("bisufad_dep") == null
+						? 0 : ((BigDecimal) propNonBat.get("bisufad_dep")).floatValue());
+				pnbGroupementCommuneRevenuImposable = pnbGroupementCommuneRevenuImposable
+						+ (propNonBat.get("bisufad_gp") == null ? 0
+								: ((BigDecimal) propNonBat.get("bisufad_gp")).floatValue());
 
-				pnbMajorationTerrain = pnbMajorationTerrain + (propNonBat.get("majposa") == null ? 0 : ((BigDecimal) propNonBat.get("majposa")).floatValue());
+				pnbMajorationTerrain = pnbMajorationTerrain + (propNonBat.get("majposa") == null ? 0
+						: ((BigDecimal) propNonBat.get("majposa")).floatValue());
 
 				pnbSurface = pnbSurface + surface;
 
@@ -320,7 +393,8 @@ public final class ProprieteHelper extends CadController {
 			}
 		}
 
-		// ajout la liste des propriete non baties uniquement si il y en a au moins une
+		// ajout la liste des propriete non baties uniquement si il y en a au
+		// moins une
 		if (!proprietesNonBaties.isEmpty()) {
 
 			// Init imposition no batie
@@ -342,23 +416,16 @@ public final class ProprieteHelper extends CadController {
 		return pnbs;
 	}
 
-
 	/**
-	 *  getLotInformation 
-	 * @param idLocal String local id from invar
+	 * getLotInformation
+	 * 
+	 * @param idLocal
+	 *            String local id from invar
 	 * @return List<Lot> bundle number and distribution in this bundle
 	 */
 	public List<Lot> getLotInformation(String idLocal) {
 
-		StringBuilder queryBuilderLots = new StringBuilder();
-		queryBuilderLots.append("select dnulot, dnumql, ddenql ");
-		queryBuilderLots.append("from ");
-		queryBuilderLots.append(databaseSchema);
-		queryBuilderLots.append(".lot l ");
-		queryBuilderLots.append(" where l.id_local = ? ");
-
-		JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-		List<Map<String, Object>> proprietesBatiesLots = jdbcTemplate.queryForList(queryBuilderLots.toString(), idLocal);
+		List<Map<String, Object>> proprietesBatiesLots = getLotInformationFromDatabase(idLocal);
 
 		List<Lot> proprieteBatieLot = new ArrayList<Lot>();
 		for (Map<String, Object> propBatLot : proprietesBatiesLots) {
@@ -378,4 +445,182 @@ public final class ProprieteHelper extends CadController {
 		return proprieteBatieLot;
 
 	}
+
+	/**
+	 * getLotInformation
+	 * 
+	 * @param idLocal
+	 *            String local id from invar
+	 * @return List<Map<String, Object>> bundle number and distribution in this bundle
+	 */
+	public List<Map<String, Object>> getLotInformationFromDatabase(String idLocal) {
+
+		StringBuilder queryBuilderLots = new StringBuilder();
+		queryBuilderLots.append("select dnulot, dnumql, ddenql ");
+		queryBuilderLots.append("from ");
+		queryBuilderLots.append(databaseSchema);
+		queryBuilderLots.append(".lot l ");
+		queryBuilderLots.append(" where l.id_local = ? ");
+
+		JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+		List<Map<String, Object>> proprietesBatiesLots = jdbcTemplate.queryForList(queryBuilderLots.toString(),
+				idLocal);
+
+		return proprietesBatiesLots;
+
+	}
+
+	/**
+	 * getLotsInformation
+	 * 
+	 * @param parcelle String
+	 * @param dnubat String
+	 * @param withOwner boolean
+	 * 
+	 * @return List<Map<String, Object>>
+	 */
+	public List<Map<String, Object>> getLotsInformation(String parcelle, String dnubat, boolean withOwner) {
+
+		logger.debug("getLotsInformation : " + parcelle + " - " + dnubat + " - " + withOwner);
+		List<String> queryParams = new ArrayList<String>();
+		queryParams.add(parcelle);
+		queryParams.add(dnubat);
+
+		StringBuilder queryBuilderLots = new StringBuilder();
+		queryBuilderLots.append(
+				"select distinct pb.parcelle, pb.invar, pb.dnubat, l.dnulot, l.dnumql, l.ddenql, pb.cconlc, dep.cconad_lib, pb.ccocac ");
+		if (withOwner) {
+			queryBuilderLots.append(" ,prop.ccodro_lib ");
+		}
+		queryBuilderLots.append(", pb.comptecommunal ");
+		if (withOwner) {
+			queryBuilderLots.append(
+					", prop.app_nom_usage, COALESCE(prop.dlign3, '')||' '||COALESCE(prop.dlign4,'')||' '||COALESCE(prop.dlign5,'')||' '||COALESCE(prop.dlign6,'') as adresse ");
+		}
+		queryBuilderLots.append(" from ");
+		queryBuilderLots.append(databaseSchema);
+		queryBuilderLots.append(".lot l, ");
+		if (withOwner) {
+			queryBuilderLots.append(databaseSchema);
+			queryBuilderLots.append(".proprietaire prop, ");
+		}
+		queryBuilderLots.append(databaseSchema);
+		queryBuilderLots.append(".proprietebatie pb, ");
+		queryBuilderLots.append(databaseSchema);
+		queryBuilderLots.append(".descdependance dep ");
+		queryBuilderLots.append(" where pb.parcelle = ? and pb.dnubat = ? ");
+		queryBuilderLots.append(" and pb.id_local =  l.id_local ");
+		if (withOwner) {
+			queryBuilderLots.append(" and pb.comptecommunal =  prop.comptecommunal ");
+		}
+		queryBuilderLots.append(" and pb.invar =  dep.invar ");
+		queryBuilderLots.append(" order by l.dnulot ");
+
+		JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+		List<Map<String, Object>> proprietesBatiesLots = jdbcTemplate.queryForList(queryBuilderLots.toString(),
+				queryParams.toArray());
+
+		return proprietesBatiesLots;
+	}
+
+	/**
+	 * getInformationLotsForPDF
+	 * 
+	 * @param parcelle String
+	 * @param dnubat String
+	 * @return InformationLots
+	 */
+	public InformationLots getInformationLotsForPDF(String parcelle, String dnubat) {
+
+		InformationLots informationLots = new InformationLots();
+		informationLots.setParcelle(parcelle);
+		informationLots.setBatiment(dnubat);
+
+		// Information d'entête
+		informationLots.setAnneMiseAJour(CadastrappPlaceHolder.getProperty("pdf.dateValiditeDonneesMajic"));
+		informationLots.setService(CadastrappPlaceHolder.getProperty("pdf.organisme"));
+
+		// get parcelle adresse
+		StringBuilder queryBuilderPLot = new StringBuilder();
+		queryBuilderPLot.append(
+				"select distinct COALESCE(p.dnvoiri, '')||' '||COALESCE(p.dindic,'')||' '||COALESCE(p.cconvo,'')||' '||COALESCE(p.dvoilib,'') as adresse ");
+		queryBuilderPLot.append(" from ");
+		queryBuilderPLot.append(databaseSchema);
+		queryBuilderPLot.append(".parcelle p ");
+		queryBuilderPLot.append(" where p.parcelle = ? ");
+
+		JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+		List<Map<String, Object>> parcelleInformations = jdbcTemplate.queryForList(queryBuilderPLot.toString(),
+				parcelle);
+
+		// Use loop because queryForObject will throw an exception if adress is empty.
+		// Even if no adresse export should be done.
+		for (Map<String, Object> parcelleInformation : parcelleInformations) {
+			informationLots.setAdresse((String) parcelleInformation.get("adresse"));
+		}
+
+		// get lot information
+		List<Map<String, Object>> listLots = getLotsInformation(parcelle, dnubat, false);
+
+		List<Lot> lots = new ArrayList();
+		int nbParts = 0;
+		for (Map<String, Object> lotInformation : listLots) {
+			Lot lot = new Lot();
+
+			lot.setLotId((String) lotInformation.get("dnulot"));
+			lot.setNumerateur((String) lotInformation.get("dnumql"));
+			nbParts = nbParts + Integer.parseInt(lot.getNumerateur());
+			lot.setDenominateur((String) lotInformation.get("ddenql"));
+
+			ProprieteBatie pb = new ProprieteBatie();
+			pb.setInvar((String) lotInformation.get("invar"));
+			pb.setCconad((String) lotInformation.get("cconad_lib"));
+			pb.setCconlc((String) lotInformation.get("cconlc"));
+			pb.setCcocac((String) lotInformation.get("ccocac"));
+
+			lot.setProprieteDescription(pb);
+
+			// get Proprietaire information
+			// Get value from database
+			// TODO this part seems to be slower, make a new request for each comptecommunal is slow.
+			// see to change for a single request
+			List<Proprietaire> proprietaires = new ArrayList<Proprietaire>();
+
+			String compteCommunal = (String) lotInformation.get("comptecommunal");
+
+			StringBuilder queryBuilder = new StringBuilder();
+			queryBuilder.append("select ccodro_lib, app_nom_usage, ");
+			queryBuilder.append(
+					" COALESCE(prop.dlign3, '')||' '||COALESCE(prop.dlign4,'')||' '||COALESCE(prop.dlign5,'')||' '||COALESCE(prop.dlign6,'') as adresse ");
+			queryBuilder.append("from ");
+			queryBuilder.append(databaseSchema);
+			queryBuilder.append(".proprietaire prop ");
+			queryBuilder.append(" where comptecommunal = ? ");
+			queryBuilder.append(" ORDER BY prop.app_nom_usage");
+
+			List<Map<String, Object>> proprietairesList = jdbcTemplate.queryForList(queryBuilder.toString(),
+					compteCommunal);
+
+			for (Map<String, Object> prop : proprietairesList) {
+
+				Proprietaire proprietaire = new Proprietaire();
+				proprietaire.setCompteCommunal(compteCommunal);
+				proprietaire.setDroitReel((String) prop.get("ccodro_lib"));
+				proprietaire.setNom((String) prop.get("app_nom_usage"));
+				proprietaire.setAdresse((String) prop.get("adresse"));
+
+				proprietaires.add(proprietaire);
+			}
+			lot.setProprietaires(proprietaires);
+
+			lots.add(lot);
+		}
+
+		informationLots.setLots(lots);
+		informationLots.setNbLots(lots.size());
+		informationLots.setSumPart(nbParts);
+
+		return informationLots;
+	}
+
 }

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/helper/ProprieteHelper.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/helper/ProprieteHelper.java
@@ -1,0 +1,361 @@
+package org.georchestra.cadastrapp.helper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.math.BigDecimal;
+
+import org.georchestra.cadastrapp.model.pdf.Imposition;
+import org.georchestra.cadastrapp.model.pdf.ImpositionNonBatie;
+import org.georchestra.cadastrapp.model.pdf.Lot;
+import org.georchestra.cadastrapp.model.pdf.ProprieteBatie;
+import org.georchestra.cadastrapp.model.pdf.ProprieteNonBatie;
+import org.georchestra.cadastrapp.model.pdf.ProprietesBaties;
+import org.georchestra.cadastrapp.model.pdf.ProprietesNonBaties;
+import org.georchestra.cadastrapp.model.pdf.Exoneration;
+import org.georchestra.cadastrapp.service.CadController;
+import org.georchestra.cadastrapp.service.constants.CadastrappConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public final class ProprieteHelper extends CadController {
+
+	static final Logger logger = LoggerFactory.getLogger(ProprieteHelper.class);
+
+	public ProprietesBaties getProprieteBatieInformation(String idCompteCommunal, String idParcelle) {
+
+		ProprietesBaties pbs = new ProprietesBaties();
+
+		// Information sur les proprietés baties
+		List<ProprieteBatie> proprietesBaties = new ArrayList<ProprieteBatie>();
+
+		float pbCommuneRevenuExonere = 0;
+		float pbCommuneRevenuImposable = 0;
+		float pbDepartementRevenuExonere = 0;
+		float pbDepartementRevenuImposable = 0;
+		float pbGroupementCommuneRevenuExonere = 0;
+		float pbGroupementCommuneRevenuImposable = 0;
+		float pbRevenuImposable = 0;
+
+		StringBuilder queryBuilderProprieteBatie = new StringBuilder();
+
+		queryBuilderProprieteBatie.append("select distinct id_local, ccopre, ccosec, dnupla, COALESCE(natvoi,'')||' '||COALESCE(dvoilib,'') as voie, ccoriv, dnubat, descr, dniv, dpor, invar, ccoaff, ccoeva, cconlc, dcapec, ccolloc, gnextl, jandeb, janimp, gtauom, pexb, rcexba2, rcbaia_com, rcbaia_dep, rcbaia_gp, rcbaia_tse, revcad, jdatat, parcelle, ccocac ");
+		queryBuilderProprieteBatie.append("from ");
+		queryBuilderProprieteBatie.append(databaseSchema);
+		queryBuilderProprieteBatie.append(".proprietebatie pb ");
+		queryBuilderProprieteBatie.append(" where pb.comptecommunal = ? ORDER BY ccosec, dnupla");
+
+		// Add map of invar to maker sure not to add two times taxable income
+		List<String> invarTICount = new ArrayList<String>();
+
+		logger.debug("Get developed property information ");
+		JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+		List<Map<String, Object>> proprietesBatiesResult = jdbcTemplate.queryForList(queryBuilderProprieteBatie.toString(), idCompteCommunal);
+
+		for (Map<String, Object> propBat : proprietesBatiesResult) {
+			if (idParcelle == null || idParcelle.isEmpty() || idParcelle.equals((String) propBat.get(CadastrappConstants.PARC_ID))) {
+				ProprieteBatie proprieteBatie = new ProprieteBatie();
+
+				if (logger.isDebugEnabled()) {
+					logger.debug("Get developed property invar : " + (String) propBat.get(CadastrappConstants.PB_NUM_INVARIANT));
+				}
+
+				String proprieteId = (String) propBat.get(CadastrappConstants.PB_NUM_INVARIANT);// N° invar
+				proprieteBatie.setInvar(proprieteId);
+				String idLocal = (String) propBat.get(CadastrappConstants.PB_ID_LOCAL);
+
+				// Add lot to list
+				proprieteBatie.setLots(getLotInformation(idLocal));
+
+				proprieteBatie.setCcoaff((String) propBat.get(CadastrappConstants.PB_AFFECTATION_PEV)); // AF
+				proprieteBatie.setCcoeva((String) propBat.get(CadastrappConstants.PB_CODE_EVAL)); // M EVAL
+				proprieteBatie.setCconlc((String) propBat.get(CadastrappConstants.PB_NATURE_LOCAL)); // NAT LOC
+				proprieteBatie.setCcocac((String) propBat.get(CadastrappConstants.PB_NATURE_LOCAL_PRO)); // NAT LOC PRO
+				proprieteBatie.setCcopre((String) propBat.get(CadastrappConstants.PREFIX_SECTION)); // N°Section part1
+				proprieteBatie.setCcoriv((String) propBat.get(CadastrappConstants.CODE_RIVOLI_VOIE)); // code rivoli
+				proprieteBatie.setCcosec((String) propBat.get(CadastrappConstants.LETTRE_SECTION)); // N°Section partt2
+				proprieteBatie.setDcapec((String) propBat.get(CadastrappConstants.PB_CATEGORIE)); // Cat
+				proprieteBatie.setDescr((String) propBat.get(CadastrappConstants.PB_NUM_ENTREE)); // Ent
+				proprieteBatie.setDniv((String) propBat.get(CadastrappConstants.PB_NIV_ETAGE)); // Niv
+				proprieteBatie.setDnubat((String) propBat.get(CadastrappConstants.PB_LETTRE_BAT)); // Bat
+				proprieteBatie.setDnupla((String) propBat.get(CadastrappConstants.NUM_PLAN)); // N° plan
+				proprieteBatie.setDpor((String) propBat.get(CadastrappConstants.PB_NUM_PORTE_LOCAL)); // N° porte
+				proprieteBatie.setRevcad(propBat.get(CadastrappConstants.PB_VAL_LOCAT_TOTAL) == null ? "" : propBat.get(CadastrappConstants.PB_VAL_LOCAT_TOTAL).toString()); // Revenu cadastral
+				proprieteBatie.setDvoilib((String) propBat.get(CadastrappConstants.ADRESSE)); // Adresse
+				proprieteBatie.setGtauom(propBat.get(CadastrappConstants.PB_MONTANT_TIEOM) == null ? "" : propBat.get(CadastrappConstants.PB_MONTANT_TIEOM).toString()); // tx OM
+				if (CadastrappConstants.MUTATION != null) {
+					// Date is store in database like jj/mm/yyyy
+					String[] parts = propBat.get(CadastrappConstants.MUTATION).toString().split("/");
+					if (parts != null && parts.length > 1) {
+						proprieteBatie.setJdatat(parts[2]);
+					}
+				}
+
+				List<Exoneration> proprieteBatieExonerations = new ArrayList<Exoneration>();
+				Exoneration proprieteBatieExoneration = new Exoneration();
+
+				proprieteBatieExoneration.setCcolloc((String) propBat.get(CadastrappConstants.PB_CODE_COLL_EXO)); // COLL
+				proprieteBatieExoneration.setGnextl((String) propBat.get(CadastrappConstants.PB_NATURE_EXO)); // Nat Exo
+				proprieteBatieExoneration.setJandeb((String) propBat.get(CadastrappConstants.PB_ANNEE_DEB_EXO)); // An Deb
+				proprieteBatieExoneration.setJanimp((String) propBat.get(CadastrappConstants.PB_ANNEE_RETOUR_IMPOSITION)); // An Ret
+				proprieteBatieExoneration.setFcexn(propBat.get(CadastrappConstants.PB_FRACTION_EXO) == null ? "" : propBat.get(CadastrappConstants.PB_FRACTION_EXO).toString()); // Fraction Exo
+				proprieteBatieExoneration.setPexb(propBat.get(CadastrappConstants.PB_TAUX_EXO_ACCORDEE) == null ? "" : propBat.get(CadastrappConstants.PB_TAUX_EXO_ACCORDEE).toString());// Exo
+
+				proprieteBatieExonerations.add(proprieteBatieExoneration);
+				proprieteBatie.setExonerations(proprieteBatieExonerations);
+
+				// Add exoneration depending on type
+				String exoneration = (String) propBat.get(CadastrappConstants.PB_CODE_COLL_EXO);
+				if (CadastrappConstants.CODE_COLL_EXO_TC.equals(exoneration)) {
+					pbCommuneRevenuExonere = pbCommuneRevenuExonere + ((BigDecimal) propBat.get(CadastrappConstants.PB_FRACTION_EXO)).floatValue();
+					pbDepartementRevenuExonere = pbDepartementRevenuExonere + ((BigDecimal) propBat.get(CadastrappConstants.PB_FRACTION_EXO)).floatValue();
+					pbGroupementCommuneRevenuExonere = pbGroupementCommuneRevenuExonere + ((BigDecimal) propBat.get(CadastrappConstants.PB_FRACTION_EXO)).floatValue();
+				} else if (CadastrappConstants.CODE_COLL_EXO_C.equals(exoneration)) {
+					pbCommuneRevenuExonere = pbCommuneRevenuExonere + ((BigDecimal) propBat.get(CadastrappConstants.PB_FRACTION_EXO)).floatValue();
+				} else if (CadastrappConstants.CODE_COLL_EXO_GC.equals(exoneration)) {
+					pbGroupementCommuneRevenuExonere = pbGroupementCommuneRevenuExonere + ((BigDecimal) propBat.get(CadastrappConstants.PB_FRACTION_EXO)).floatValue();
+				} else if (CadastrappConstants.CODE_COLL_EXO_D.equals(exoneration)) {
+					pbDepartementRevenuExonere = pbDepartementRevenuExonere + ((BigDecimal) propBat.get(CadastrappConstants.PB_FRACTION_EXO)).floatValue();
+				} else if (CadastrappConstants.CODE_COLL_EXO_A.equals(exoneration)) {
+					logger.debug("Exoneration on additional taxes");
+				}
+
+				// Count only one taxable income for one invar
+				if (!invarTICount.contains(proprieteId)) {
+					invarTICount.add(proprieteId);
+
+					float communeRevenuImposable = propBat.get("rcbaia_com") == null ? 0 : ((BigDecimal) propBat.get("rcbaia_com")).floatValue();
+					float groupementCommuneRevenuImposable = propBat.get("rcbaia_gp") == null ? 0 : ((BigDecimal) propBat.get("rcbaia_gp")).floatValue();
+					float departementRevenuImposable = propBat.get("rcbaia_dep") == null ? 0 : ((BigDecimal) propBat.get("rcbaia_dep")).floatValue();
+					float tseRevenuImposable = propBat.get("rcbaia_tse") == null ? 0 : ((BigDecimal) propBat.get("rcbaia_tse")).floatValue();
+
+					Imposition pbImposition = new Imposition();
+
+					pbImposition.setCommuneRevenuImposable(communeRevenuImposable);
+					pbImposition.setGroupementCommuneRevenuImposable(groupementCommuneRevenuImposable);
+					pbImposition.setDepartementRevenuImposable(departementRevenuImposable);
+					pbImposition.setTseRevenuImposable(tseRevenuImposable);
+
+					proprieteBatie.setImposition(pbImposition);
+
+					pbRevenuImposable = pbRevenuImposable + (propBat.get(CadastrappConstants.PB_VAL_LOCAT_TOTAL) == null ? 0 : ((BigDecimal) propBat.get(CadastrappConstants.PB_VAL_LOCAT_TOTAL)).floatValue());
+					pbCommuneRevenuImposable = pbCommuneRevenuImposable + communeRevenuImposable;
+					pbDepartementRevenuImposable = pbDepartementRevenuImposable + departementRevenuImposable;
+					pbGroupementCommuneRevenuImposable = pbGroupementCommuneRevenuImposable + groupementCommuneRevenuImposable;
+				}
+
+				proprietesBaties.add(proprieteBatie);
+			}
+		}
+		// ajout la liste des propriete baties uniquement si il y en a au moins une
+		if (!proprietesBaties.isEmpty()) {
+
+			// Init imposition batie
+			Imposition impositionBatie = new Imposition();
+			impositionBatie.setCommuneRevenuExonere(pbCommuneRevenuExonere);
+			impositionBatie.setCommuneRevenuImposable(pbCommuneRevenuImposable);
+			impositionBatie.setDepartementRevenuExonere(pbDepartementRevenuExonere);
+			impositionBatie.setDepartementRevenuImposable(pbDepartementRevenuImposable);
+			impositionBatie.setGroupementCommuneRevenuExonere(pbGroupementCommuneRevenuExonere);
+			impositionBatie.setGroupementCommuneRevenuImposable(pbGroupementCommuneRevenuImposable);
+			impositionBatie.setRevenuImposable(pbRevenuImposable);
+
+			pbs.setImposition(impositionBatie);
+			pbs.setProprietes(proprietesBaties);
+		}
+		return pbs;
+	}
+
+	public ProprietesNonBaties getProprieteNonBatieInformation(String idCompteCommunal, String idParcelle) {
+
+		ProprietesNonBaties pnbs = new ProprietesNonBaties();
+
+		// Information sur les proprietés non baties
+		List<ProprieteNonBatie> proprietesNonBaties = new ArrayList<ProprieteNonBatie>();
+
+		float pnbCommuneRevenuExonere = 0;
+		float pnbCommuneRevenuImposable = 0;
+		float pnbDepartementRevenuExonere = 0;
+		float pnbDepartementRevenuImposable = 0;
+		float pnbGroupementCommuneRevenuExonere = 0;
+		float pnbGroupementCommuneRevenuImposable = 0;
+		float pnbRevenuImposable = 0;
+		float pnbMajorationTerrain = 0;
+		int pnbSurface = 0;
+
+		StringBuilder queryBuilderProprieteNonBatie = new StringBuilder();
+
+		queryBuilderProprieteNonBatie.append("select distinct pnb.id_local, pnb.cgocommune, pnb.ccopre, pnb.ccosec, pnb.dnupla, ");
+		queryBuilderProprieteNonBatie.append("COALESCE(pnb.natvoi,'')||' '||COALESCE(pnb.dvoilib,'') as voie, pnb.ccoriv, pnb.dparpi, ");
+		queryBuilderProprieteNonBatie.append("pnb.ccostn, pnb.ccosub, pnb.cgrnum, pnb.dsgrpf, pnb.dclssf, pnb.cnatsp, pnb.dcntsf, pnb.drcsuba, ");
+		queryBuilderProprieteNonBatie.append("pnb.dnulot, pnb.dreflf, pnb.majposa, pnb.bisufad_com, pnb.bisufad_dep, pnb.bisufad_gp, pnb.gparnf, ");
+		queryBuilderProprieteNonBatie.append("pnb.jdatat, pnb.parcelle ");
+		queryBuilderProprieteNonBatie.append("from ");
+		queryBuilderProprieteNonBatie.append(databaseSchema);
+		queryBuilderProprieteNonBatie.append(".proprietenonbatie pnb ");
+		queryBuilderProprieteNonBatie.append(" where pnb.comptecommunal = ? ORDER BY ccosec, dnupla");
+
+		logger.debug("Get undeveloped property information ");
+		JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+		List<Map<String, Object>> proprietesNonBatiesResult = jdbcTemplate.queryForList(queryBuilderProprieteNonBatie.toString(), idCompteCommunal);
+
+		for (Map<String, Object> propNonBat : proprietesNonBatiesResult) {
+			if (idParcelle == null || idParcelle.isEmpty() || idParcelle.equals((String) propNonBat.get(CadastrappConstants.PARC_ID))) {
+				String proprieteNbId = (String) propNonBat.get("id_local");
+
+				if (logger.isDebugEnabled()) {
+					logger.debug("Get undeveloped property id : " + proprieteNbId);
+				}
+
+				// Get exonerations for this PNB
+				StringBuilder queryBuilderProprieteNonBatieExo = new StringBuilder();
+				queryBuilderProprieteNonBatieExo.append("SELECT pnbsufexo.id_local, pnbsufexo.ccolloc, pnbsufexo.gnexts, pnbsufexo.jfinex, ");
+				queryBuilderProprieteNonBatieExo.append("pnbsufexo.rcexnba, pnbsufexo.pexn ");
+				queryBuilderProprieteNonBatieExo.append("from ");
+				queryBuilderProprieteNonBatieExo.append(databaseSchema);
+				queryBuilderProprieteNonBatieExo.append(".proprietenonbatiesufexo pnbsufexo ");
+				queryBuilderProprieteNonBatieExo.append(" where pnbsufexo.cgocommune = ? and pnbsufexo.id_local = ? ORDER BY ccolloc");
+				List<Map<String, Object>> proprieteNonBatieExonerationsResult = jdbcTemplate.queryForList(queryBuilderProprieteNonBatieExo.toString(), (String) propNonBat.get("cgocommune"), proprieteNbId);
+
+				List<Exoneration> proprieteNonBatieExonerations = new ArrayList<Exoneration>();
+				for (Map<String, Object> propNonBatExo : proprieteNonBatieExonerationsResult) {
+					Exoneration proprieteNonBatieExoneration = new Exoneration();
+
+					proprieteNonBatieExoneration.setCcolloc((String) propNonBatExo.get(CadastrappConstants.PNB_CODE_COLL_EXO));
+					proprieteNonBatieExoneration.setGnextl((String) propNonBatExo.get(CadastrappConstants.PNB_NATURE_EXO));
+					proprieteNonBatieExoneration.setJanimp((String) propNonBatExo.get(CadastrappConstants.PNB_ANNEE_RETOUR_IMPOSITION));
+					proprieteNonBatieExoneration.setFcexn(propNonBatExo.get(CadastrappConstants.PNB_FRACTION_RC_EXO) == null ? "" : propNonBatExo.get(CadastrappConstants.PNB_FRACTION_RC_EXO).toString());
+					proprieteNonBatieExoneration.setPexb(propNonBatExo.get(CadastrappConstants.PNB_POURCENTAGE_EXO) == null ? "" : propNonBatExo.get(CadastrappConstants.PNB_POURCENTAGE_EXO).toString());// à
+
+					proprieteNonBatieExonerations.add(proprieteNonBatieExoneration);
+
+					// "TC";"toutes les collectivités"
+					// "R";"Région => l'exonération porte sur la seule part régionale"
+					// "GC";"Groupement de communes"
+					// "D";"Département => l'exonération porte sur la seule part départementale"
+					// "C";"Commune => l'exonération porte sur la seule part communale"
+					// "A";"l'exonération porte sur la taxe additionnelle"
+					String exonerationType = (String) propNonBatExo.get(CadastrappConstants.PNB_CODE_COLL_EXO);
+					float exonerationValue = (propNonBatExo.get("rcexnba") == null ? 0 : ((BigDecimal) propNonBatExo.get("rcexnba")).floatValue());
+					if (CadastrappConstants.CODE_COLL_EXO_TC.equals(exonerationType)) {
+						pnbCommuneRevenuExonere = pnbCommuneRevenuExonere + exonerationValue;
+						pnbDepartementRevenuExonere = pnbDepartementRevenuExonere + exonerationValue;
+						pnbGroupementCommuneRevenuExonere = pnbGroupementCommuneRevenuExonere + exonerationValue;
+					} else if (CadastrappConstants.CODE_COLL_EXO_C.equals(exonerationType)) {
+						pnbCommuneRevenuExonere = pnbCommuneRevenuExonere + exonerationValue;
+					} else if (CadastrappConstants.CODE_COLL_EXO_GC.equals(exonerationType)) {
+						pnbGroupementCommuneRevenuExonere = pnbGroupementCommuneRevenuExonere + exonerationValue;
+					} else if (CadastrappConstants.CODE_COLL_EXO_D.equals(exonerationType)) {
+						pnbDepartementRevenuExonere = pnbDepartementRevenuExonere + exonerationValue;
+					} else if (CadastrappConstants.CODE_COLL_EXO_A.equals(exonerationType)) {
+						logger.debug("Exoneration on additional taxes");
+					}
+				}
+
+				ProprieteNonBatie proprieteNonBatie = new ProprieteNonBatie();
+
+				proprieteNonBatie.setCcopre((String) propNonBat.get(CadastrappConstants.PREFIX_SECTION));
+				proprieteNonBatie.setCcoriv((String) propNonBat.get(CadastrappConstants.CODE_RIVOLI_VOIE));
+				proprieteNonBatie.setCcosec((String) propNonBat.get(CadastrappConstants.LETTRE_SECTION));
+				proprieteNonBatie.setCcostn((String) propNonBat.get(CadastrappConstants.PNB_SERIE_TARIF));
+				proprieteNonBatie.setCcosub((String) propNonBat.get(CadastrappConstants.PNB_LETTRE_SUF));
+				proprieteNonBatie.setCgrnum((String) propNonBat.get(CadastrappConstants.PNB_GROUP_NATURE_CULTURE));
+				proprieteNonBatie.setCnatsp((String) propNonBat.get(CadastrappConstants.PNB_CODE_NAT_CULT));
+				proprieteNonBatie.setDclssf((String) propNonBat.get(CadastrappConstants.PNB_CLASSE));
+				proprieteNonBatie.setDnulot((String) propNonBat.get(CadastrappConstants.PNB_REF_LOT));
+				proprieteNonBatie.setDnupla((String) propNonBat.get(CadastrappConstants.NUM_PLAN));
+				proprieteNonBatie.setDparpi((String) propNonBat.get(CadastrappConstants.PNB_NUM_PARC_PRIM));
+				proprieteNonBatie.setDreflf((String) propNonBat.get("dreflf"));
+				proprieteNonBatie.setDsgrpf((String) propNonBat.get(CadastrappConstants.PNB_SOUS_GROUP));
+				proprieteNonBatie.setDvoilib((String) propNonBat.get(CadastrappConstants.ADRESSE));
+				proprieteNonBatie.setGparnf((String) propNonBat.get(CadastrappConstants.PNB_FPDP));
+				proprieteNonBatie.setExonerations(proprieteNonBatieExonerations);
+
+				if (CadastrappConstants.MUTATION != null) {
+					// Date is store in database like jj/mm/yyyy
+					String[] parts = propNonBat.get(CadastrappConstants.MUTATION).toString().split("/");
+					if (parts != null && parts.length > 1) {
+						proprieteNonBatie.setJdatat(parts[2]);
+					}
+				}
+
+				int surface = (Integer) propNonBat.get(CadastrappConstants.PNB_CONTENANCE_CA) == null ? 0 : (Integer) propNonBat.get(CadastrappConstants.PNB_CONTENANCE_CA);
+				proprieteNonBatie.setDcntsf(surface);
+
+				float revenu = propNonBat.get(CadastrappConstants.PNB_REVENU_CADASTRAL) == null ? 0 : ((BigDecimal) propNonBat.get(CadastrappConstants.PNB_REVENU_CADASTRAL)).floatValue();
+				proprieteNonBatie.setDrcsuba(revenu);
+
+				pnbRevenuImposable = pnbRevenuImposable + revenu;
+
+				pnbCommuneRevenuImposable = pnbCommuneRevenuImposable + (propNonBat.get("bisufad_com") == null ? 0 : ((BigDecimal) propNonBat.get("bisufad_com")).floatValue());
+				pnbDepartementRevenuImposable = pnbDepartementRevenuImposable + (propNonBat.get("bisufad_dep") == null ? 0 : ((BigDecimal) propNonBat.get("bisufad_dep")).floatValue());
+				pnbGroupementCommuneRevenuImposable = pnbGroupementCommuneRevenuImposable + (propNonBat.get("bisufad_gp") == null ? 0 : ((BigDecimal) propNonBat.get("bisufad_gp")).floatValue());
+
+				pnbMajorationTerrain = pnbMajorationTerrain + (propNonBat.get("majposa") == null ? 0 : ((BigDecimal) propNonBat.get("majposa")).floatValue());
+
+				pnbSurface = pnbSurface + surface;
+
+				proprietesNonBaties.add(proprieteNonBatie);
+			}
+		}
+
+		// ajout la liste des propriete non baties uniquement si il y en a au moins une
+		if (!proprietesNonBaties.isEmpty()) {
+
+			// Init imposition no batie
+			ImpositionNonBatie impositionNonBatie = new ImpositionNonBatie();
+			impositionNonBatie.setCommuneRevenuExonere(pnbCommuneRevenuExonere);
+			impositionNonBatie.setCommuneRevenuImposable(pnbCommuneRevenuImposable);
+			impositionNonBatie.setDepartementRevenuExonere(pnbDepartementRevenuExonere);
+			impositionNonBatie.setDepartementRevenuImposable(pnbDepartementRevenuImposable);
+			impositionNonBatie.setGroupementCommuneRevenuExonere(pnbGroupementCommuneRevenuExonere);
+			impositionNonBatie.setGroupementCommuneRevenuImposable(pnbGroupementCommuneRevenuImposable);
+			impositionNonBatie.setRevenuImposable(pnbRevenuImposable);
+			impositionNonBatie.setMajorationTerraion(pnbMajorationTerrain);
+			impositionNonBatie.setSurface(pnbSurface);
+
+			pnbs.setImposition(impositionNonBatie);
+			pnbs.setProprietes(proprietesNonBaties);
+		}
+
+		return pnbs;
+	}
+
+	// TODO try changing this,
+	// making a request on each loop might not the best solution,
+	// but it can have more than one lot for one invar
+	// Make sure an index exist on id_local
+	public List<Lot> getLotInformation(String idLocal) {
+
+		StringBuilder queryBuilderLots = new StringBuilder();
+		queryBuilderLots.append("select dnulot, dnumql, ddenql ");
+		queryBuilderLots.append("from ");
+		queryBuilderLots.append(databaseSchema);
+		queryBuilderLots.append(".lot l ");
+		queryBuilderLots.append(" where l.id_local = ? ");
+
+		JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+		List<Map<String, Object>> proprietesBatiesLots = jdbcTemplate.queryForList(queryBuilderLots.toString(), idLocal);
+
+		List<Lot> proprieteBatieLot = new ArrayList<Lot>();
+		for (Map<String, Object> propBatLot : proprietesBatiesLots) {
+			// Create lot and add information
+			Lot lot = new Lot();
+			lot.setLotId((String) propBatLot.get(CadastrappConstants.PB_LOT_ID));
+			lot.setDenominateur((String) propBatLot.get(CadastrappConstants.PB_LOT_DENOMINATEUR));
+			lot.setNumerateur((String) propBatLot.get(CadastrappConstants.PB_LOT_NUMERATEUR));
+
+			if (logger.isDebugEnabled()) {
+				logger.debug("Lot : " + lot);
+			}
+
+			// add lot to list
+			proprieteBatieLot.add(lot);
+		}
+		return proprieteBatieLot;
+
+	}
+}

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/model/pdf/CompteCommunal.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/model/pdf/CompteCommunal.java
@@ -21,13 +21,9 @@ public class CompteCommunal {
 	
 	private List<Proprietaire> proprietaires;
 	
-	private List<ProprieteBatie> proprieteBaties;
+	private ProprietesBaties proprieteBaties;
 	
-	private Imposition impositionBatie;
-	
-	private List<ProprieteNonBatie> proprieteNonBaties;
-	
-	private ImpositionNonBatie impositionNonBatie;
+	private ProprietesNonBaties proprieteNonBaties;
 
 
 	/**
@@ -64,32 +60,30 @@ public class CompteCommunal {
 	/**
 	 * @return the proprieteBaties
 	 */
-	public List<ProprieteBatie> getProprieteBaties() {
+	public ProprietesBaties getProprietesBaties() {
 		return proprieteBaties;
 	}
 
-	@XmlElementWrapper(name="proprietesBaties", nillable=true)
-    @XmlElements({@XmlElement(name="proprieteBatie", type=ProprieteBatie.class, nillable = true)})
+    @XmlElements({@XmlElement(name="proprietesBaties", type=ProprietesBaties.class, nillable = true)})
 	/**
 	 * @param proprieteBaties the proprieteBaties to set
 	 */
-	public void setProprieteBaties(List<ProprieteBatie> proprieteBaties) {
+	public void setProprietesBaties(ProprietesBaties proprieteBaties) {
 		this.proprieteBaties = proprieteBaties;
 	}
 
 	/**
 	 * @return the proprieteNonBaties
 	 */
-	public List<ProprieteNonBatie> getProprieteNonBaties() {
+	public ProprietesNonBaties getProprietesNonBaties() {
 		return proprieteNonBaties;
 	}
 
-	@XmlElementWrapper(name="proprietesNonBaties", nillable=true)
-    @XmlElements({@XmlElement(name="proprieteNonBatie",     type=ProprieteNonBatie.class, nillable = true)})
+    @XmlElements({@XmlElement(name="proprietesNonBaties",     type=ProprietesNonBaties.class, nillable = true)})
 	/**
 	 * @param proprieteNonBaties the proprieteNonBaties to set
 	 */
-	public void setProprieteNonBaties(List<ProprieteNonBatie> proprieteNonBaties) {
+	public void setProprietesNonBaties(ProprietesNonBaties proprieteNonBaties) {
 		this.proprieteNonBaties = proprieteNonBaties;
 	}
 
@@ -152,36 +146,5 @@ public class CompteCommunal {
 	public void setNumeroCommunal(String numeroCommunal) {
 		this.numeroCommunal = numeroCommunal;
 	}
-
-	/**
-	 * @return the impositionBatie
-	 */
-	public Imposition getImpositionBatie() {
-		return impositionBatie;
-	}
-
-	@XmlElement(name="impositionBatie",     type=Imposition.class, nillable = true)
-	/**
-	 * @param impositionBatie the impositionBatie to set
-	 */
-	public void setImpositionBatie(Imposition impositionBatie) {
-		this.impositionBatie = impositionBatie;
-	}
-
-	/**
-	 * @return the impositionNonBatie
-	 */
-	public ImpositionNonBatie getImpositionNonBatie() {
-		return impositionNonBatie;
-	}
-
-	@XmlElement(name="impositionNonBatie",     type=ImpositionNonBatie.class, nillable = true)
-	/**
-	 * @param impositionNonBatie the impositionNonBatie to set
-	 */
-	public void setImpositionNonBatie(ImpositionNonBatie impositionNonBatie) {
-		this.impositionNonBatie = impositionNonBatie;
-	}
-
 
 }

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/model/pdf/InformationLots.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/model/pdf/InformationLots.java
@@ -1,0 +1,158 @@
+package org.georchestra.cadastrapp.model.pdf;
+
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlElements;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement
+public class InformationLots {
+
+	private String parcelle;
+
+	private String adresse;
+	
+	private String batiment;
+
+	private int nbLots;
+
+	private int sumPart;
+	
+	private String service;
+	
+	private String anneMiseAJour;
+
+	private List<Lot> lots;
+
+	public InformationLots() {
+	}
+
+	@XmlElementWrapper(name = "lots")
+	@XmlElements({ @XmlElement(name = "Lot", type = Lot.class) })
+	/**
+	 * @param lots
+	 */
+	public void setLots(List<Lot> lots) {
+		this.lots = lots;
+	}
+
+	/**
+	 *  @return lots
+	 */
+	public List<Lot> getLots() {
+		return lots;
+	}
+
+	/**
+	 * @return the plot id
+	 */
+	public String getParcelle() {
+		return parcelle;
+	}
+
+	@XmlElement
+	/**
+	 * @param parcelle
+	 *            the plot to set
+	 */
+	public void setParcelle(String parcelle) {
+		this.parcelle = parcelle;
+	}
+
+	/**
+	 * @return the adresse
+	 */
+	public String getAdresse() {
+		return adresse;
+	}
+
+	@XmlElement
+	/**
+	 * @param adresse
+	 *            the adresse to set
+	 */
+	public void setAdresse(String adresse) {
+		this.adresse = adresse;
+	}
+
+	/**
+	 * 
+	 * @return the lots number
+	 */
+	public int getNbLots() {
+		return nbLots;
+	}
+
+	@XmlElement
+	/**
+	 * 
+	 * @param nbLots
+	 * 			the nbLots to set
+	 */
+	public void setNbLots(int nbLots) {
+		this.nbLots = nbLots;
+	}
+
+	/**
+	 * 
+	 * @return the sum of all bundle 
+	 */
+	public int getSumPart() {
+		return sumPart;
+	}
+
+	@XmlElement
+	/**
+	 @param sumPart
+	 * 			the sumPart to set
+	 */
+	public void setSumPart(int sumPart) {
+		this.sumPart = sumPart;
+	}
+
+	/**
+	 * @return the batiment
+	 */
+	public String getBatiment() {
+		return batiment;
+	}
+
+	@XmlElement
+	/**
+	 * @param batiment the batiment to set
+	 */
+	public void setBatiment(String batiment) {
+		this.batiment = batiment;
+	}
+
+	/**
+	 * @return the service
+	 */
+	public String getService() {
+		return service;
+	}
+
+	/**
+	 * @param service the service to set
+	 */
+	public void setService(String service) {
+		this.service = service;
+	}
+
+	/**
+	 * @return the anneMiseAJour
+	 */
+	public String getAnneMiseAJour() {
+		return anneMiseAJour;
+	}
+
+	/**
+	 * @param anneMiseAJour the anneMiseAJour to set
+	 */
+	public void setAnneMiseAJour(String anneMiseAJour) {
+		this.anneMiseAJour = anneMiseAJour;
+	}
+
+}

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/model/pdf/Lot.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/model/pdf/Lot.java
@@ -1,6 +1,11 @@
 package org.georchestra.cadastrapp.model.pdf;
 
+import java.util.List;
+
 import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlElements;
 
 
 public class Lot {
@@ -13,6 +18,28 @@ public class Lot {
 	
 	// Dénominateur ddenql
 	private String denominateur;
+	
+	private ProprieteBatie proprieteDescription;
+	
+	// Optional
+	private List<Proprietaire> proprietaires;
+
+
+	@XmlElementWrapper(name = "proprietaires")
+	@XmlElements({ @XmlElement(name = "Proprietaire", type = Proprietaire.class) })
+	/**
+	 * @param proprietaires
+	 */
+	public void setProprietaires(List<Proprietaire> proprietaires) {
+		this.proprietaires = proprietaires;
+	}
+
+	/**
+	 * @return the proprietaires
+	 */
+	public List<Proprietaire> getProprietaires() {
+		return proprietaires;
+	}
 
 	/**
 	 * @return the lotId
@@ -59,6 +86,21 @@ public class Lot {
 		this.denominateur = denominateur;
 	}
 
+	/**
+	 * @return the proprieteDescription
+	 */
+	public ProprieteBatie getProprieteDescription() {
+		return proprieteDescription;
+	}
+
+	@XmlElements({ @XmlElement(name = "Propriete", type = ProprieteBatie.class) })
+	/**
+	 * @param proprieteDescription the proprieteDescription to set
+	 */
+	public void setProprieteDescription(ProprieteBatie proprieteDescription) {
+		this.proprieteDescription = proprieteDescription;
+	}
+	
 	/* (non-Javadoc)
 	 * @see java.lang.Object#toString()
 	 */
@@ -66,6 +108,7 @@ public class Lot {
 	public String toString() {
 		return "Lot [lotId=" + lotId + ", repartition : " + numerateur + "/" + denominateur + "]";
 	}
+
 
 
 }

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/model/pdf/ProprieteBatie.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/model/pdf/ProprieteBatie.java
@@ -36,6 +36,9 @@ public class ProprieteBatie extends Propriete{
 	// Nature du local professionel
 	private String ccocac;
 	
+	// Nature de la dépendance
+	private String cconad;
+	
 	// Catégorie
 	private String dcapec;
 	
@@ -45,7 +48,7 @@ public class ProprieteBatie extends Propriete{
 	// Zone de ramassage
 	private String gtauom;
 	
-	// Liste de lots
+	// Liste de lots optional
 	private List<Lot> lots;
 	
 	// Imposition
@@ -260,6 +263,21 @@ public class ProprieteBatie extends Propriete{
 	 */
 	public void setLots(List<Lot> lots) {
 		this.lots = lots;
+	}
+
+	/**
+	 * @return the cconad
+	 */
+	public String getCconad() {
+		return cconad;
+	}
+
+	@XmlAttribute
+	/**
+	 * @param cconad the cconad to set
+	 */
+	public void setCconad(String cconad) {
+		this.cconad = cconad;
 	}
 }
 

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/model/pdf/ProprietesBaties.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/model/pdf/ProprietesBaties.java
@@ -1,0 +1,48 @@
+package org.georchestra.cadastrapp.model.pdf;
+
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlElements;
+
+public class ProprietesBaties {
+	
+
+	// Liste de lots
+	private List<ProprieteBatie> proprietes;
+	
+	private Imposition imposition;
+	
+	/**
+	 * @return the impositionBatie
+	 */
+	public Imposition getImposition() {
+		return imposition;
+	}
+
+	@XmlElement(name="imposition",     type=Imposition.class, nillable = true)
+	/**
+	 * @param impositionBatie the impositionBatie to set
+	 */
+	public void setImposition(Imposition imposition) {
+		this.imposition = imposition;
+	}
+
+	/**
+	 * @return list of proprietes
+	 */
+	public List<ProprieteBatie> getProprietes() {
+		return proprietes;
+	}
+
+	@XmlElementWrapper(name="proprietes")
+    @XmlElements({@XmlElement(name="propriete",   type=ProprieteBatie.class)})
+	/**
+	 * @param proprietes
+	 */
+	public void setProprietes(List<ProprieteBatie> proprietes) {
+		this.proprietes = proprietes;
+	}
+}
+

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/model/pdf/ProprietesNonBaties.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/model/pdf/ProprietesNonBaties.java
@@ -1,0 +1,48 @@
+package org.georchestra.cadastrapp.model.pdf;
+
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlElements;
+
+public class ProprietesNonBaties {
+	
+
+	// Liste de lots
+	private List<ProprieteNonBatie> proprietes;
+	
+	private Imposition imposition;
+	
+	/**
+	 * @return the impositionBatie
+	 */
+	public Imposition getImposition() {
+		return imposition;
+	}
+
+	@XmlElement(name="imposition",     type=Imposition.class, nillable = true)
+	/**
+	 * @param impositionBatie the impositionBatie to set
+	 */
+	public void setImposition(Imposition imposition) {
+		this.imposition = imposition;
+	}
+
+	/**
+	 * @return list of proprietes
+	 */
+	public List<ProprieteNonBatie> getProprietes() {
+		return proprietes;
+	}
+
+	@XmlElementWrapper(name="proprietes")
+    @XmlElements({@XmlElement(name="propriete",   type=ProprieteNonBatie.class)})
+	/**
+	 * @param proprietes
+	 */
+	public void setProprietes(List<ProprieteNonBatie> proprietes) {
+		this.proprietes = proprietes;
+	}
+}
+

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/CoProprietaireController.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/CoProprietaireController.java
@@ -473,10 +473,10 @@ public class CoProprietaireController extends CadController {
 							out.close();
 						}
 						if(xmlfile != null){
-					//	xmlfile.delete();
+							xmlfile.delete();
 						}
 						if(foFile != null){
-					//		foFile.delete();
+							foFile.delete();
 						}
 						if (foOutPutStream != null){
 							foOutPutStream.close();

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/CoProprietaireController.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/CoProprietaireController.java
@@ -1,9 +1,16 @@
 package org.georchestra.cadastrapp.service;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -20,8 +27,29 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.transform.Result;
+import javax.xml.transform.Source;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.sax.SAXResult;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.fop.apps.FOPException;
+import org.apache.fop.apps.Fop;
+import org.apache.fop.apps.FopFactory;
+import org.apache.fop.apps.MimeConstants;
+import org.georchestra.cadastrapp.configuration.CadastrappPlaceHolder;
+import org.georchestra.cadastrapp.helper.ProprieteHelper;
+import org.georchestra.cadastrapp.model.pdf.BordereauParcellaire;
+import org.georchestra.cadastrapp.model.pdf.InformationLots;
 import org.georchestra.cadastrapp.service.export.ExportHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,6 +68,9 @@ public class CoProprietaireController extends CadController {
 	
 	@Autowired
 	ExportHelper exportHelper;
+	
+	@Autowired
+	ProprieteHelper proprieteHelper;
 
 	@Path("/getCoProprietaireList")
 	@GET
@@ -262,6 +293,211 @@ public class CoProprietaireController extends CadController {
 				//log empty request
 				logger.info("Parcelle Id List is empty nothing to search");
 			}
+		}else{
+			logger.info("User does not have rights to see thoses informations");
+		}
+	
+		return response.build();
+	}
+	
+	@POST
+	@Path("/exportLotsAsCSV")
+	@Produces("text/csv")
+	/**
+	 * Create a csv file from given plot and building id
+	 * 
+	 * @param headers Used to filter displayed information
+	 * @param parcelle String
+	 * @param dnubat String
+	 * 
+	 * @return csv containing bundle information
+	 * 
+	 * @throws SQLException
+	 */
+	public Response exportLotsAsSCV(
+			@Context HttpHeaders headers,
+			@FormParam("parcelle") String parcelle, @FormParam("dnubat") String dnubat) throws SQLException {
+		
+		// Create empty content
+		ResponseBuilder response = Response.noContent();
+		
+		if(getUserCNILLevel(headers)>0){
+			logger.debug("Input parameters are : " + parcelle + " - " + dnubat);
+			
+			String entete = "parcelle_num;numero_invariant;batiment;numero_lot;part_lot;total_lot;logement;dependance;local_commerciale;type_proprietaire;compte_communal;nom_proprietaire;adresse";
+				
+			// Get value from database with owner values
+			List<Map<String,Object>> bundleResults = proprieteHelper.getLotsInformation(parcelle, dnubat, true);
+					
+			File file = null;
+			try{
+				file = exportHelper.createCSV(bundleResults, entete);
+				
+				// build csv response
+				response = Response.ok((Object) file);
+				response.header("Content-Disposition", "attachment; filename=" + file.getName());
+			}catch (IOException e) {
+				logger.error("Error while creating CSV files ", e);
+			} finally {
+				if (file != null) {
+					file.deleteOnExit();
+				}
+			}
+		}else{
+			logger.info("User does not have rights to see thoses informations");
+		}
+	
+		return response.build();
+	}
+	
+	@POST
+	@Path("/exportLotsAsPDF")
+	@Produces("application/pdf")
+	/**
+	 * Create a pdf file from given plot and building id
+	 * 
+	 * @param headers Used to filter displayed information
+	 * @param parcelle String
+	 * @param dnubat String
+	 * 
+	 * @return pdf containing bundle information
+	 * 
+	 * @throws SQLException
+	 */
+	public Response exportLotsAsPDF(
+			@Context HttpHeaders headers,
+			@FormParam("parcelle") String parcelle, @FormParam("dnubat") String dnubat) throws SQLException {
+		
+		// Create empty content
+		ResponseBuilder response = Response.noContent();
+		
+		if(getUserCNILLevel(headers)>0){
+			logger.debug("Input parameters are : " + parcelle + " - " + dnubat);
+			final String xslTemplate = "xsl/lots.xsl";
+			
+			// Check if parcelle list is not empty
+			if (parcelle != null && dnubat != null) {
+				
+				String tempFolder = CadastrappPlaceHolder.getProperty("tempFolder");
+				
+				// Pdf temporary filename using tmp folder and timestamp
+				final String pdfTmpFileName = tempFolder+File.separator+"Lots"+new Date().getTime();
+
+				// Construct a FopFactory (reuse if you plan to render multiple documents!)
+				FopFactory fopFactory = FopFactory.newInstance();
+				InputStream xsl = Thread.currentThread().getContextClassLoader().getResourceAsStream(xslTemplate);
+
+				// Setup XSLT
+				TransformerFactory factory = TransformerFactory.newInstance();
+
+				Transformer transformerXSLT;
+				Transformer transformerPDF;
+				JAXBContext jaxbContext;
+				Marshaller jaxbMarshaller;
+				File pdfResult;
+				OutputStream out;
+				Fop fop;
+
+				try {
+					transformerXSLT = factory.newTransformer(new StreamSource(xsl));
+					transformerPDF = factory.newTransformer();
+
+					// Create Empyt PDF File will be erase after
+					pdfResult = new File(pdfTmpFileName+".pdf");
+					pdfResult.deleteOnExit();
+					
+					out = new BufferedOutputStream(new FileOutputStream(pdfResult));
+
+					fop = fopFactory.newFop(MimeConstants.MIME_PDF, out);
+
+					jaxbContext = JAXBContext.newInstance(InformationLots.class);
+					jaxbMarshaller = jaxbContext.createMarshaller();
+
+					jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+
+					// Get bordereau parcellaire information
+					InformationLots informationLots = proprieteHelper.getInformationLotsForPDF(parcelle, dnubat);
+					File xmlfile = null;
+					File foFile = null;
+					OutputStream foOutPutStream = null;
+					
+					try {
+						// Xml file will be deleted on JVM exit
+						xmlfile = new File(pdfTmpFileName+".xml");
+						xmlfile.deleteOnExit();
+						
+						jaxbMarshaller.marshal(informationLots, xmlfile);
+
+						// log on console marshaller only if debug log is one
+						if (logger.isDebugEnabled()) {
+							jaxbMarshaller.marshal(informationLots, System.out);
+						}
+
+						// FO file will be deleted on JVM exit
+						// XML TO FO
+						foFile = new File(pdfTmpFileName+".fo");
+						foFile.deleteOnExit();
+						
+						foOutPutStream = new java.io.FileOutputStream(foFile);
+
+						// Setup input for XSLT transformation
+						Source srcXml = new StreamSource(xmlfile);
+						Result resFo = new StreamResult(foOutPutStream);
+
+						// Start XSLT transformation and FOP processing
+						transformerXSLT.transform(srcXml, resFo);
+						foOutPutStream.close();
+
+						// FO TO PDF
+						Source src = new StreamSource(foFile);
+						Result res = new SAXResult(fop.getDefaultHandler());
+
+						// Start PDF transformation and FOP processing
+						transformerPDF.transform(src, res);
+
+						out.close();
+						
+						// Create response
+						response = Response.ok((Object) pdfResult);
+						response.header("Content-Disposition", "attachment; filename=" + pdfResult.getName());
+
+					} catch (JAXBException jaxbException) {
+						logger.warn("Error during converting object to xml : " + jaxbException);
+					} catch (TransformerException transformerException) {
+						logger.warn("Error during converting object to xml : " + transformerException);
+					} catch (FileNotFoundException fileNotFoundException) {
+						logger.warn("Error when using temporary files : " + fileNotFoundException);
+					} finally {
+						if (out != null) {
+							// Clean-up
+							out.close();
+						}
+						if(xmlfile != null){
+					//	xmlfile.delete();
+						}
+						if(foFile != null){
+					//		foFile.delete();
+						}
+						if (foOutPutStream != null){
+							foOutPutStream.close();
+						}
+					}
+
+				} catch (TransformerConfigurationException e) {
+					logger.warn("Error when initialize transformers : " + e);
+				} catch (IOException ioException) {
+					logger.warn("Error when creating output file : " + ioException);
+				} catch (FOPException fopException) {
+					logger.warn("Error when creationg FOP file type : " + fopException);
+				} catch (JAXBException jaxbException) {
+					logger.warn("Error creating Marsharller : " + jaxbException);
+				}finally{
+					// Could not delete pdfResult here because it's still used by cxf
+				}
+			} else {
+				logger.warn("Required parameter missing");
+			}
+
 		}else{
 			logger.info("User does not have rights to see thoses informations");
 		}

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/UniteCadastraleController.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/UniteCadastraleController.java
@@ -12,14 +12,19 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 
+import org.georchestra.cadastrapp.helper.BatimentHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 
 public class UniteCadastraleController extends CadController {
 
 	final static Logger logger = LoggerFactory.getLogger(UniteCadastraleController.class);
+	
+	@Autowired
+	BatimentHelper batimentHelper;
 
 	@Path("/getFIC")
 	@GET
@@ -34,7 +39,7 @@ public class UniteCadastraleController extends CadController {
 	 * @param part (for 0 to 5)
 	 * 			0 -> Parcelle Information
 	 * 			1 -> Proprietaire information
-	 * 			2 -> Dnubat batiments lists
+	 * 			2 -> Dnubat batiments lists (deprecated since 1.6 version)
 	 * 			3 - > Subdivision information
 	 * 			4 - > Historical information
 	 * @return Json object corresponding on wanted part
@@ -61,7 +66,7 @@ public class UniteCadastraleController extends CadController {
 				break;
 			case 2:
 				if (getUserCNILLevel(headers)>1){
-					information = infoOngletBatimentList(parcelle, headers);
+					information = batimentHelper.getBuildings(parcelle, headers);
 				}
 				else{
 					logger.info("User does not have enough right to see information about batiment");
@@ -148,32 +153,7 @@ public class UniteCadastraleController extends CadController {
 		return jdbcTemplate.queryForList(queryBuilder.toString(), parcelle);	
 	}
 	
-	/**
-	 * 
-	 * infoOngletBatimentList
-	 * 
-	 * @param String parcelle / Id Parcelle exemple : 2014630103000AP0025
-	 * @param HttpHeaders headers
-	 * 
-	 * @return List<Map<String, Object>> 
-	 */
-	private List<Map<String, Object>> infoOngletBatimentList(String parcelle, HttpHeaders headers ){
-		
-		logger.debug("infoOngletBatiment - parcelle : " + parcelle);
-		
-		StringBuilder queryBuilder = new StringBuilder();
-		
-		// CNIL Niveau 2
-		queryBuilder.append("select distinct pb.dnubat from ");
-		queryBuilder.append(databaseSchema);
-		queryBuilder.append(".proprietebatie pb ");
-		queryBuilder.append(" where pb.parcelle = ? ");
-		queryBuilder.append(addAuthorizationFiltering(headers, "pb."));
-		queryBuilder.append(" ORDER BY pb.dnubat");
-		
-		JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
-		return jdbcTemplate.queryForList(queryBuilder.toString(), parcelle);		
-	}
+	
 		
 	/**
 	 *  infoOngletSubdivision get information about subdivision

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/export/ExportHelper.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/export/ExportHelper.java
@@ -33,9 +33,6 @@ public class ExportHelper {
 	 */
 	public File createCSV(List<Map<String, Object>> data, String entete) throws IOException {
 
-		// Parse value to have only once a comptecommunal, but with several
-		// parcelle
-		// at this time there is one comptecommunal for each parcelle
 		String tempFolder = CadastrappPlaceHolder.getProperty("tempFolder");
 
 		// File with current time

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/pdf/ReleveProprieteHelper.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/pdf/ReleveProprieteHelper.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.math.BigDecimal;
 
 import javax.ws.rs.core.HttpHeaders;
 import javax.xml.bind.JAXBContext;
@@ -32,19 +31,14 @@ import org.apache.fop.apps.Fop;
 import org.apache.fop.apps.FopFactory;
 import org.apache.fop.apps.MimeConstants;
 import org.georchestra.cadastrapp.configuration.CadastrappPlaceHolder;
+import org.georchestra.cadastrapp.helper.ProprieteHelper;
 import org.georchestra.cadastrapp.model.pdf.CompteCommunal;
-import org.georchestra.cadastrapp.model.pdf.Imposition;
-import org.georchestra.cadastrapp.model.pdf.ImpositionNonBatie;
-import org.georchestra.cadastrapp.model.pdf.Lot;
 import org.georchestra.cadastrapp.model.pdf.Proprietaire;
-import org.georchestra.cadastrapp.model.pdf.ProprieteBatie;
-import org.georchestra.cadastrapp.model.pdf.ProprieteNonBatie;
 import org.georchestra.cadastrapp.model.pdf.RelevePropriete;
-import org.georchestra.cadastrapp.model.pdf.Exoneration;
 import org.georchestra.cadastrapp.service.CadController;
-import org.georchestra.cadastrapp.service.constants.CadastrappConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
@@ -52,6 +46,9 @@ import org.springframework.stereotype.Component;
 public final class ReleveProprieteHelper extends CadController {
 
 	static final Logger logger = LoggerFactory.getLogger(ReleveProprieteHelper.class);
+	
+	@Autowired
+	ProprieteHelper proprieteHelper;
 
 	static final String XSL_TEMPLATE = "xsl/relevePropriete.xsl";
 	static final String XSL_TEMPLATE_MINIMAL = "xsl/releveProprieteMinimal.xsl";
@@ -191,319 +188,12 @@ public final class ReleveProprieteHelper extends CadController {
 						}
 						// Ajout la liste des proprietaires
 						compteCommunal.setProprietaires(proprietaires);
+				
+						compteCommunal.setProprietesBaties(proprieteHelper.getProprieteBatieInformation(idCompteCommunal, idParcelle));
 
-						// Information sur les proprietés baties
-						List<ProprieteBatie> proprietesBaties = new ArrayList<ProprieteBatie>();
+						compteCommunal.setProprietesNonBaties(proprieteHelper.getProprieteNonBatieInformation(idCompteCommunal, idParcelle));
 
-						float pbCommuneRevenuExonere = 0;
-						float pbCommuneRevenuImposable = 0;
-						float pbDepartementRevenuExonere = 0;
-						float pbDepartementRevenuImposable = 0;
-						float pbGroupementCommuneRevenuExonere = 0;
-						float pbGroupementCommuneRevenuImposable = 0;
-						float pbRevenuImposable = 0;
-
-						StringBuilder queryBuilderProprieteBatie = new StringBuilder();
-
-						queryBuilderProprieteBatie.append("select distinct id_local, ccopre, ccosec, dnupla, COALESCE(natvoi,'')||' '||COALESCE(dvoilib,'') as voie, ccoriv, dnubat, descr, dniv, dpor, invar, ccoaff, ccoeva, cconlc, dcapec, ccolloc, gnextl, jandeb, janimp, gtauom, pexb, rcexba2, rcbaia_com, rcbaia_dep, rcbaia_gp, rcbaia_tse, revcad, jdatat, parcelle, ccocac ");
-						queryBuilderProprieteBatie.append("from ");
-						queryBuilderProprieteBatie.append(databaseSchema);
-						queryBuilderProprieteBatie.append(".proprietebatie pb ");
-						queryBuilderProprieteBatie.append(" where pb.comptecommunal = ? ORDER BY ccosec, dnupla");
-
-						// Add map of invar to maker sure not to add two times taxable income
-						List<String> invarTICount = new ArrayList<String>();
-
-						logger.debug("Get developed property information ");
-						List<Map<String, Object>> proprietesBatiesResult = jdbcTemplate.queryForList(queryBuilderProprieteBatie.toString(), idCompteCommunal);
-
-						for (Map<String, Object> propBat : proprietesBatiesResult) {
-							if (idParcelle == null || idParcelle.isEmpty() || idParcelle.equals((String) propBat.get(CadastrappConstants.PARC_ID))) {
-								ProprieteBatie proprieteBatie = new ProprieteBatie();
-
-								if (logger.isDebugEnabled()) {
-									logger.debug("Get developed property invar : " + (String) propBat.get(CadastrappConstants.PB_NUM_INVARIANT));
-								}
-
-								String proprieteId = (String) propBat.get(CadastrappConstants.PB_NUM_INVARIANT);//N° invar
-								proprieteBatie.setInvar(proprieteId);
-
-								// TODO try changing this, 
-								// making a request on each loop might not the best solution, but it can have more than one lot for one invar
-								// Make sure an index exist on id_local
-								String idLocal = (String) propBat.get(CadastrappConstants.PB_ID_LOCAL);
-
-								StringBuilder queryBuilderLots = new StringBuilder();
-								queryBuilderLots.append("select dnulot, dnumql, ddenql ");
-								queryBuilderLots.append("from ");
-								queryBuilderLots.append(databaseSchema);
-								queryBuilderLots.append(".lot l ");
-								queryBuilderLots.append(" where l.id_local = ? ");
-								List<Map<String, Object>> proprietesBatiesLots = jdbcTemplate.queryForList(queryBuilderLots.toString(), idLocal);
-
-								List<Lot> proprieteBatieLot = new ArrayList<Lot>();
-								for (Map<String, Object> propBatLot : proprietesBatiesLots) {
-									// Create lot and add information
-									Lot lot = new Lot();
-									lot.setLotId((String) propBatLot.get(CadastrappConstants.PB_LOT_ID));
-									lot.setDenominateur((String) propBatLot.get(CadastrappConstants.PB_LOT_DENOMINATEUR));
-									lot.setNumerateur((String) propBatLot.get(CadastrappConstants.PB_LOT_NUMERATEUR));
-
-									if (logger.isDebugEnabled()) {
-										logger.debug("Lot : " + lot);
-									}
-
-									// add lot to list
-									proprieteBatieLot.add(lot);
-								}
-								// Add lot to list
-								proprieteBatie.setLots(proprieteBatieLot);
-
-								proprieteBatie.setCcoaff((String) propBat.get(CadastrappConstants.PB_AFFECTATION_PEV)); //AF
-								proprieteBatie.setCcoeva((String) propBat.get(CadastrappConstants.PB_CODE_EVAL)); //M EVAL
-								proprieteBatie.setCconlc((String) propBat.get(CadastrappConstants.PB_NATURE_LOCAL)); //NAT LOC
-								proprieteBatie.setCcocac((String) propBat.get(CadastrappConstants.PB_NATURE_LOCAL_PRO)); //NAT LOC PRO
-								proprieteBatie.setCcopre((String) propBat.get(CadastrappConstants.PREFIX_SECTION)); //N°SETCION part1
-								proprieteBatie.setCcoriv((String) propBat.get(CadastrappConstants.CODE_RIVOLI_VOIE)); //code rivoli
-								proprieteBatie.setCcosec((String) propBat.get(CadastrappConstants.LETTRE_SECTION)); //N°SETCION part2
-								proprieteBatie.setDcapec((String) propBat.get(CadastrappConstants.PB_CATEGORIE)); //Cat
-								proprieteBatie.setDescr((String) propBat.get(CadastrappConstants.PB_NUM_ENTREE)); //Ent
-								proprieteBatie.setDniv((String) propBat.get(CadastrappConstants.PB_NIV_ETAGE)); //Niv
-								proprieteBatie.setDnubat((String) propBat.get(CadastrappConstants.PB_LETTRE_BAT)); //Bat
-								proprieteBatie.setDnupla((String) propBat.get(CadastrappConstants.NUM_PLAN)); //N° plan
-								proprieteBatie.setDpor((String) propBat.get(CadastrappConstants.PB_NUM_PORTE_LOCAL)); //N° porte
-								proprieteBatie.setRevcad(propBat.get(CadastrappConstants.PB_VAL_LOCAT_TOTAL) == null ? "" : propBat.get(CadastrappConstants.PB_VAL_LOCAT_TOTAL).toString()); //Revenu cadastral
-								proprieteBatie.setDvoilib((String) propBat.get(CadastrappConstants.ADRESSE)); //Adresse
-								proprieteBatie.setGtauom(propBat.get(CadastrappConstants.PB_MONTANT_TIEOM) == null ? "" : propBat.get(CadastrappConstants.PB_MONTANT_TIEOM).toString()); //tx OM
-
-								if (CadastrappConstants.MUTATION != null) {
-									// Date is store in database like jj/mm/yyyy
-									String[] parts = propBat.get(CadastrappConstants.MUTATION).toString().split("/");
-									if (parts != null && parts.length > 1) {
-										proprieteBatie.setJdatat(parts[2]);
-									}
-								}
-
-								List<Exoneration> proprieteBatieExonerations = new ArrayList<Exoneration>();
-								Exoneration proprieteBatieExoneration = new Exoneration();
-
-								proprieteBatieExoneration.setCcolloc((String) propBat.get(CadastrappConstants.PB_CODE_COLL_EXO)); //COLL
-								proprieteBatieExoneration.setGnextl((String) propBat.get(CadastrappConstants.PB_NATURE_EXO)); //Nat Exo
-								proprieteBatieExoneration.setJandeb((String) propBat.get(CadastrappConstants.PB_ANNEE_DEB_EXO)); //An Deb
-								proprieteBatieExoneration.setJanimp((String) propBat.get(CadastrappConstants.PB_ANNEE_RETOUR_IMPOSITION)); //An Ret
-								proprieteBatieExoneration.setFcexn(propBat.get(CadastrappConstants.PB_FRACTION_EXO) == null ? "" : propBat.get(CadastrappConstants.PB_FRACTION_EXO).toString()); //Fraction Exo
-								proprieteBatieExoneration.setPexb(propBat.get(CadastrappConstants.PB_TAUX_EXO_ACCORDEE) == null ? "" : propBat.get(CadastrappConstants.PB_TAUX_EXO_ACCORDEE).toString());//Exo
-
-								proprieteBatieExonerations.add(proprieteBatieExoneration);
-								proprieteBatie.setExonerations(proprieteBatieExonerations);
-
-								// Add exoneration depending on type
-								String exoneration = (String) propBat.get(CadastrappConstants.PB_CODE_COLL_EXO);
-								if (CadastrappConstants.CODE_COLL_EXO_TC.equals(exoneration)) {
-									pbCommuneRevenuExonere = pbCommuneRevenuExonere + ((BigDecimal) propBat.get(CadastrappConstants.PB_FRACTION_EXO)).floatValue();
-									pbDepartementRevenuExonere = pbDepartementRevenuExonere + ((BigDecimal) propBat.get(CadastrappConstants.PB_FRACTION_EXO)).floatValue();
-									pbGroupementCommuneRevenuExonere = pbGroupementCommuneRevenuExonere + ((BigDecimal) propBat.get(CadastrappConstants.PB_FRACTION_EXO)).floatValue();
-								} else if (CadastrappConstants.CODE_COLL_EXO_C.equals(exoneration)) {
-									pbCommuneRevenuExonere = pbCommuneRevenuExonere + ((BigDecimal) propBat.get(CadastrappConstants.PB_FRACTION_EXO)).floatValue();
-								} else if (CadastrappConstants.CODE_COLL_EXO_GC.equals(exoneration)) {
-									pbGroupementCommuneRevenuExonere = pbGroupementCommuneRevenuExonere + ((BigDecimal) propBat.get(CadastrappConstants.PB_FRACTION_EXO)).floatValue();
-								} else if (CadastrappConstants.CODE_COLL_EXO_D.equals(exoneration)) {
-									pbDepartementRevenuExonere = pbDepartementRevenuExonere + ((BigDecimal) propBat.get(CadastrappConstants.PB_FRACTION_EXO)).floatValue();
-								} else if (CadastrappConstants.CODE_COLL_EXO_A.equals(exoneration)) {
-									logger.debug("Exoneration on additional taxes");
-								}
-
-								// Count only one taxable income for one invar
-								if (!invarTICount.contains(proprieteId)) {
-									invarTICount.add(proprieteId);
-									
-									float communeRevenuImposable = propBat.get("rcbaia_com") == null ? 0 : ((BigDecimal) propBat.get("rcbaia_com")).floatValue();
-									float groupementCommuneRevenuImposable = propBat.get("rcbaia_gp") == null ? 0 : ((BigDecimal) propBat.get("rcbaia_gp")).floatValue();
-									float departementRevenuImposable = propBat.get("rcbaia_dep") == null ? 0 : ((BigDecimal) propBat.get("rcbaia_dep")).floatValue();
-									float tseRevenuImposable = propBat.get("rcbaia_tse") == null ? 0 : ((BigDecimal) propBat.get("rcbaia_tse")).floatValue();
-									
-									Imposition pbImposition = new Imposition();
-									
-									pbImposition.setCommuneRevenuImposable(communeRevenuImposable);
-									pbImposition.setGroupementCommuneRevenuImposable(groupementCommuneRevenuImposable);
-									pbImposition.setDepartementRevenuImposable(departementRevenuImposable);
-									pbImposition.setTseRevenuImposable(tseRevenuImposable);
-									
-									proprieteBatie.setImposition(pbImposition);
-									
-									pbRevenuImposable = pbRevenuImposable + (propBat.get(CadastrappConstants.PB_VAL_LOCAT_TOTAL) == null ? 0 : ((BigDecimal) propBat.get(CadastrappConstants.PB_VAL_LOCAT_TOTAL)).floatValue());
-									pbCommuneRevenuImposable = pbCommuneRevenuImposable + communeRevenuImposable;
-									pbDepartementRevenuImposable = pbDepartementRevenuImposable + departementRevenuImposable;
-									pbGroupementCommuneRevenuImposable = pbGroupementCommuneRevenuImposable + groupementCommuneRevenuImposable;
-								}
-
-								proprietesBaties.add(proprieteBatie);
-							}
-						}
-						// ajout la liste des propriete baties uniquement si il y en a
-						// au moins une
-						if (!proprietesBaties.isEmpty()) {
-
-							// Init imposition batie
-							Imposition impositionBatie = new Imposition();
-							impositionBatie.setCommuneRevenuExonere(pbCommuneRevenuExonere);
-							impositionBatie.setCommuneRevenuImposable(pbCommuneRevenuImposable);
-							impositionBatie.setDepartementRevenuExonere(pbDepartementRevenuExonere);
-							impositionBatie.setDepartementRevenuImposable(pbDepartementRevenuImposable);
-							impositionBatie.setGroupementCommuneRevenuExonere(pbGroupementCommuneRevenuExonere);
-							impositionBatie.setGroupementCommuneRevenuImposable(pbGroupementCommuneRevenuImposable);
-							impositionBatie.setRevenuImposable(pbRevenuImposable);
-
-							compteCommunal.setImpositionBatie(impositionBatie);
-
-							compteCommunal.setProprieteBaties(proprietesBaties);
-						}
-
-						// Information sur les proprietés non baties
-						List<ProprieteNonBatie> proprietesNonBaties = new ArrayList<ProprieteNonBatie>();
-
-						float pnbCommuneRevenuExonere = 0;
-						float pnbCommuneRevenuImposable = 0;
-						float pnbDepartementRevenuExonere = 0;
-						float pnbDepartementRevenuImposable = 0;
-						float pnbGroupementCommuneRevenuExonere = 0;
-						float pnbGroupementCommuneRevenuImposable = 0;
-						float pnbRevenuImposable = 0;
-						float pnbMajorationTerrain = 0;
-						int pnbSurface = 0;
-
-						StringBuilder queryBuilderProprieteNonBatie = new StringBuilder();
-
-						queryBuilderProprieteNonBatie
-								.append("select distinct pnb.id_local, pnb.cgocommune, pnb.ccopre, pnb.ccosec, pnb.dnupla, COALESCE(pnb.natvoi,'')||' '||COALESCE(pnb.dvoilib,'') as voie, pnb.ccoriv, pnb.dparpi, pnb.ccostn, pnb.ccosub, pnb.cgrnum, pnb.dsgrpf, pnb.dclssf, pnb.cnatsp, pnb.dcntsf, pnb.drcsuba, pnb.dnulot, pnb.dreflf, pnb.majposa, pnb.bisufad_com, pnb.bisufad_dep, pnb.bisufad_gp, pnb.gparnf, pnb.jdatat, pnb.parcelle ");
-						queryBuilderProprieteNonBatie.append("from ");
-						queryBuilderProprieteNonBatie.append(databaseSchema);
-						queryBuilderProprieteNonBatie.append(".proprietenonbatie pnb ");
-						queryBuilderProprieteNonBatie.append(" where pnb.comptecommunal = ? ORDER BY ccosec, dnupla");
-
-						logger.debug("Get undeveloped property information ");
-						List<Map<String, Object>> proprietesNonBatiesResult = jdbcTemplate.queryForList(queryBuilderProprieteNonBatie.toString(), idCompteCommunal);
-
-						for (Map<String, Object> propNonBat : proprietesNonBatiesResult) {
-							if (idParcelle == null || idParcelle.isEmpty() || idParcelle.equals((String) propNonBat.get(CadastrappConstants.PARC_ID))) {
-								String proprieteNbId = (String) propNonBat.get("id_local");
-
-								if (logger.isDebugEnabled()) {
-									logger.debug("Get undeveloped property id : " + proprieteNbId);
-								}
-
-								// Get exonerations for this PNB
-								StringBuilder queryBuilderProprieteNonBatieExo = new StringBuilder();
-								queryBuilderProprieteNonBatieExo.append("SELECT pnbsufexo.id_local, pnbsufexo.ccolloc, pnbsufexo.gnexts, pnbsufexo.jfinex, pnbsufexo.rcexnba, pnbsufexo.pexn ");
-								queryBuilderProprieteNonBatieExo.append("from ");
-								queryBuilderProprieteNonBatieExo.append(databaseSchema);
-								queryBuilderProprieteNonBatieExo.append(".proprietenonbatiesufexo pnbsufexo ");
-								queryBuilderProprieteNonBatieExo.append(" where pnbsufexo.cgocommune = ? and pnbsufexo.id_local = ? ORDER BY ccolloc");
-								List<Map<String, Object>> proprieteNonBatieExonerationsResult = jdbcTemplate.queryForList(queryBuilderProprieteNonBatieExo.toString(), (String) propNonBat.get("cgocommune"), proprieteNbId);
-
-								List<Exoneration> proprieteNonBatieExonerations = new ArrayList<Exoneration>();
-								for (Map<String, Object> propNonBatExo : proprieteNonBatieExonerationsResult) {
-									Exoneration proprieteNonBatieExoneration = new Exoneration();
-
-									proprieteNonBatieExoneration.setCcolloc((String) propNonBatExo.get(CadastrappConstants.PNB_CODE_COLL_EXO));
-									proprieteNonBatieExoneration.setGnextl((String) propNonBatExo.get(CadastrappConstants.PNB_NATURE_EXO));
-									proprieteNonBatieExoneration.setJanimp((String) propNonBatExo.get(CadastrappConstants.PNB_ANNEE_RETOUR_IMPOSITION));
-									proprieteNonBatieExoneration.setFcexn(propNonBatExo.get(CadastrappConstants.PNB_FRACTION_RC_EXO) == null ? "" : propNonBatExo.get(CadastrappConstants.PNB_FRACTION_RC_EXO).toString());
-									proprieteNonBatieExoneration.setPexb(propNonBatExo.get(CadastrappConstants.PNB_POURCENTAGE_EXO) == null ? "" : propNonBatExo.get(CadastrappConstants.PNB_POURCENTAGE_EXO).toString());//à voir si besoin de divider par 100
-
-									proprieteNonBatieExonerations.add(proprieteNonBatieExoneration);
-
-									// "TC";"toutes les collectivités"
-									// "R";"Région => l'exonération porte sur la seule part régionale"
-									// "GC";"Groupement de communes"
-									// "D";"Département => l'exonération porte sur la seule part départementale"
-									// "C";"Commune => l'exonération porte sur la seule part communale"
-									// "A";"l'exonération porte sur la taxe additionnelle"
-									String exonerationType = (String) propNonBatExo.get(CadastrappConstants.PNB_CODE_COLL_EXO);
-									float exonerationValue = (propNonBatExo.get("rcexnba") == null ? 0 : ((BigDecimal) propNonBatExo.get("rcexnba")).floatValue());
-									if (CadastrappConstants.CODE_COLL_EXO_TC.equals(exonerationType)) {
-										pnbCommuneRevenuExonere = pnbCommuneRevenuExonere + exonerationValue;
-										pnbDepartementRevenuExonere = pnbDepartementRevenuExonere + exonerationValue;
-										pnbGroupementCommuneRevenuExonere = pnbGroupementCommuneRevenuExonere + exonerationValue;
-									} else if (CadastrappConstants.CODE_COLL_EXO_C.equals(exonerationType)) {
-										pnbCommuneRevenuExonere = pnbCommuneRevenuExonere + exonerationValue;
-									} else if (CadastrappConstants.CODE_COLL_EXO_GC.equals(exonerationType)) {
-										pnbGroupementCommuneRevenuExonere = pnbGroupementCommuneRevenuExonere + exonerationValue;
-									} else if (CadastrappConstants.CODE_COLL_EXO_D.equals(exonerationType)) {
-										pnbDepartementRevenuExonere = pnbDepartementRevenuExonere + exonerationValue;
-									} else if (CadastrappConstants.CODE_COLL_EXO_A.equals(exonerationType)) {
-										logger.debug("Exoneration on additional taxes");
-									}
-								}
-
-								ProprieteNonBatie proprieteNonBatie = new ProprieteNonBatie();
-
-								proprieteNonBatie.setCcopre((String) propNonBat.get(CadastrappConstants.PREFIX_SECTION));
-								proprieteNonBatie.setCcoriv((String) propNonBat.get(CadastrappConstants.CODE_RIVOLI_VOIE));
-								proprieteNonBatie.setCcosec((String) propNonBat.get(CadastrappConstants.LETTRE_SECTION));
-								proprieteNonBatie.setCcostn((String) propNonBat.get(CadastrappConstants.PNB_SERIE_TARIF));
-								proprieteNonBatie.setCcosub((String) propNonBat.get(CadastrappConstants.PNB_LETTRE_SUF));
-								proprieteNonBatie.setCgrnum((String) propNonBat.get(CadastrappConstants.PNB_GROUP_NATURE_CULTURE));
-								proprieteNonBatie.setCnatsp((String) propNonBat.get(CadastrappConstants.PNB_CODE_NAT_CULT));
-								proprieteNonBatie.setDclssf((String) propNonBat.get(CadastrappConstants.PNB_CLASSE));
-								proprieteNonBatie.setDnulot((String) propNonBat.get(CadastrappConstants.PNB_REF_LOT));
-								proprieteNonBatie.setDnupla((String) propNonBat.get(CadastrappConstants.NUM_PLAN));
-								proprieteNonBatie.setDparpi((String) propNonBat.get(CadastrappConstants.PNB_NUM_PARC_PRIM));
-								proprieteNonBatie.setDreflf((String) propNonBat.get("dreflf"));
-								proprieteNonBatie.setDsgrpf((String) propNonBat.get(CadastrappConstants.PNB_SOUS_GROUP));
-								proprieteNonBatie.setDvoilib((String) propNonBat.get(CadastrappConstants.ADRESSE));
-								proprieteNonBatie.setGparnf((String) propNonBat.get(CadastrappConstants.PNB_FPDP));
-								proprieteNonBatie.setExonerations(proprieteNonBatieExonerations);
-
-								if (CadastrappConstants.MUTATION != null) {
-									// Date is store in database like jj/mm/yyyy
-									String[] parts = propNonBat.get(CadastrappConstants.MUTATION).toString().split("/");
-									if (parts != null && parts.length > 1) {
-										proprieteNonBatie.setJdatat(parts[2]);
-									}
-								}
-
-								int surface = (Integer) propNonBat.get(CadastrappConstants.PNB_CONTENANCE_CA) == null ? 0 : (Integer) propNonBat.get(CadastrappConstants.PNB_CONTENANCE_CA);
-								proprieteNonBatie.setDcntsf(surface);
-
-								float revenu = propNonBat.get(CadastrappConstants.PNB_REVENU_CADASTRAL) == null ? 0 : ((BigDecimal) propNonBat.get(CadastrappConstants.PNB_REVENU_CADASTRAL)).floatValue();
-								proprieteNonBatie.setDrcsuba(revenu);
-
-								pnbRevenuImposable = pnbRevenuImposable + revenu;
-
-								pnbCommuneRevenuImposable = pnbCommuneRevenuImposable + (propNonBat.get("bisufad_com") == null ? 0 : ((BigDecimal) propNonBat.get("bisufad_com")).floatValue());
-								pnbDepartementRevenuImposable = pnbDepartementRevenuImposable + (propNonBat.get("bisufad_dep") == null ? 0 : ((BigDecimal) propNonBat.get("bisufad_dep")).floatValue());
-								pnbGroupementCommuneRevenuImposable = pnbGroupementCommuneRevenuImposable + (propNonBat.get("bisufad_gp") == null ? 0 : ((BigDecimal) propNonBat.get("bisufad_gp")).floatValue());
-
-								pnbMajorationTerrain = pnbMajorationTerrain + (propNonBat.get("majposa") == null ? 0 : ((BigDecimal) propNonBat.get("majposa")).floatValue());
-
-								pnbSurface = pnbSurface + surface;
-
-								proprietesNonBaties.add(proprieteNonBatie);
-							}
-						}
-
-						// ajout la liste des propriete non baties uniquement si il y en
-						// a au moins une
-						if (!proprietesNonBaties.isEmpty()) {
-
-							// Init imposition no batie
-							ImpositionNonBatie impositionNonBatie = new ImpositionNonBatie();
-							impositionNonBatie.setCommuneRevenuExonere(pnbCommuneRevenuExonere);
-							impositionNonBatie.setCommuneRevenuImposable(pnbCommuneRevenuImposable);
-							impositionNonBatie.setDepartementRevenuExonere(pnbDepartementRevenuExonere);
-							impositionNonBatie.setDepartementRevenuImposable(pnbDepartementRevenuImposable);
-							impositionNonBatie.setGroupementCommuneRevenuExonere(pnbGroupementCommuneRevenuExonere);
-							impositionNonBatie.setGroupementCommuneRevenuImposable(pnbGroupementCommuneRevenuImposable);
-							impositionNonBatie.setRevenuImposable(pnbRevenuImposable);
-							impositionNonBatie.setMajorationTerraion(pnbMajorationTerrain);
-							impositionNonBatie.setSurface(pnbSurface);
-
-							compteCommunal.setImpositionNonBatie(impositionNonBatie);
-
-							compteCommunal.setProprieteNonBaties(proprietesNonBaties);
-						}
-
+					
 						// Ajout du compte communal à la liste
 						comptesCommunaux.add(compteCommunal);
 					}

--- a/cadastrapp/src/main/resources/xsl/lots.xsl
+++ b/cadastrapp/src/main/resources/xsl/lots.xsl
@@ -1,0 +1,266 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+	xmlns:fo="http://www.w3.org/1999/XSL/Format" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:java="http://xml.apache.org/xslt/java" xmlns:date="http://exslt.org/dates-and-times"
+	exclude-result-prefixes="java">
+	<xsl:decimal-format name="euro" decimal-separator="," grouping-separator=" " NaN=" "/>
+	
+	<!-- Page layout information -->
+	<xsl:template match="/">
+		<fo:root xmlns:fo="http://www.w3.org/1999/XSL/Format">
+			<fo:layout-master-set>
+				<fo:simple-page-master master-name="portrait"
+					page-height="21cm" page-width="29.7cm" font-family="sans-serif"
+					margin-top="0.5cm" margin-bottom="0.5cm" margin-left="0.5cm"
+					margin-right="0.5cm">
+					<fo:region-body />
+				</fo:simple-page-master>
+			</fo:layout-master-set>
+			
+			<fo:page-sequence master-reference="portrait">
+				<fo:flow flow-name="xsl-region-body">
+					<xsl:apply-templates select="informationLots" />
+				</fo:flow>
+			</fo:page-sequence>
+		</fo:root>
+	</xsl:template>
+	
+	<!-- Style Titre -->
+	<xsl:attribute-set name="titre">
+		<xsl:attribute name="text-align">center</xsl:attribute>
+		<xsl:attribute name="padding-top">5pt</xsl:attribute>
+		<xsl:attribute name="font-size">10pt</xsl:attribute>
+		<xsl:attribute name="font-weight">bold</xsl:attribute>
+	</xsl:attribute-set>
+	
+	<!-- Bordure de tableau -->
+	<xsl:attribute-set name="bordure">
+		<xsl:attribute name="border">solid 1 black</xsl:attribute>
+		<xsl:attribute name="text-align">center</xsl:attribute>
+		<xsl:attribute name="font-size">6pt</xsl:attribute>
+		<xsl:attribute name="padding">2pt</xsl:attribute>
+	</xsl:attribute-set>
+	
+	<!-- Style attributions -->
+	<xsl:attribute-set name="attributions">
+		<xsl:attribute name="text-align">center</xsl:attribute>
+		<xsl:attribute name="padding-top">5pt</xsl:attribute>
+		<xsl:attribute name="font-size">5pt</xsl:attribute>
+		<xsl:attribute name="font-style">italic</xsl:attribute>
+	</xsl:attribute-set>
+	
+	<xsl:variable name="anneMiseAJour">
+		<xsl:value-of select="informationLots/anneMiseAJour" />
+	</xsl:variable>
+
+	<xsl:variable name="service">
+		<xsl:value-of select="informationLots/service" />
+	</xsl:variable>
+
+	<!-- Définition des informations communes -->
+	<xsl:variable name="dateDeCreation">
+		<xsl:value-of
+			select="java:format(java:java.text.SimpleDateFormat.new('d MMMM yyyy'), java:java.util.Date.new())" />
+	</xsl:variable>
+	
+	<!--  template global -->
+	<xsl:template match="informationLots">
+		<!-- Pour description de la parcelle -->
+		<xsl:if test="parcelle">
+			<xsl:call-template name="entete" />
+		</xsl:if>
+			
+		<!-- liste des proprietaires d'un compte communal -->
+		<xsl:if test="lots">
+			<xsl:call-template name="lot" />
+		</xsl:if>
+					
+		<fo:block>&#160;</fo:block>
+		<fo:block xsl:use-attribute-sets="attributions">
+			<xsl:value-of select="$service" />
+		</fo:block>
+		<fo:block xsl:use-attribute-sets="attributions">
+			Ce document est donné à titre indicatif - Il n'a pas de valeur légale
+		</fo:block>
+	</xsl:template>
+	
+	<!-- Cartouche d'entête de chaque relevé, présent uniquement sur la premiere page   -->
+	<xsl:template name="entete">
+		<fo:block xsl:use-attribute-sets="titre" page-break-before="always">Lots de copropriété</fo:block>
+		<fo:table table-layout="fixed">
+			<fo:table-column column-width="30%" />
+			<fo:table-column column-width="40%" />
+			<fo:table-column column-width="30%" />
+			<fo:table-body>
+				<fo:table-row>
+					<fo:table-cell>
+						<fo:block text-align="start" font-size="8" padding-top="8pt">
+							Date de mise à jour des données :
+							<xsl:value-of select="$anneMiseAJour" />
+						</fo:block>
+						<fo:block text-align="start" font-size="8">
+							Date de création du document :
+							<xsl:value-of select="$dateDeCreation" />
+						</fo:block>
+					</fo:table-cell>
+					<fo:table-cell>
+						<fo:block text-align="center" padding-top="8pt">
+							Parcelle :
+							<xsl:value-of select="parcelle" />
+						</fo:block>
+						<fo:block text-align="center">
+							Batiment :
+							<xsl:value-of select="batiment" />
+						</fo:block>
+						<fo:block text-align="center">
+							Adresse :
+							<xsl:value-of select="adresse" />
+						</fo:block>
+					</fo:table-cell>
+					<fo:table-cell>
+						<fo:block text-align="end" padding-top="8pt">
+							Nombre de lots :
+							<xsl:value-of select="nbLots" />
+						</fo:block>
+						<fo:block text-align="end">
+							Somme des parts :
+							<xsl:value-of select="sumPart" />
+						</fo:block>
+					</fo:table-cell>
+				</fo:table-row>
+			</fo:table-body>
+		</fo:table>
+	</xsl:template>
+	
+	<!-- Liste des propriétaires comprenant Droit, Nom, Adresse et information de naissance  -->
+	<xsl:template name="proprietaire">
+		<fo:table table-layout="fixed">
+			<fo:table-column column-width="20%" />
+			<fo:table-column column-width="40%" />
+			<fo:table-column column-width="40%" />
+			<fo:table-body>
+				<xsl:for-each select="proprietaires/Proprietaire">
+					<fo:table-row>
+						<fo:table-cell>
+							<fo:block>
+								<xsl:value-of select="@compteCommunal" />
+							</fo:block>
+						</fo:table-cell>
+						<fo:table-cell>
+							<fo:block>
+								<xsl:value-of select="@droitReel" />
+							</fo:block>
+							<fo:block>
+								<xsl:value-of select="@nom" />
+							</fo:block>
+						</fo:table-cell>
+								<fo:table-cell>
+							<fo:block>
+								<xsl:value-of select="@adresse" />
+							</fo:block>
+						</fo:table-cell>
+					</fo:table-row>
+				</xsl:for-each>
+			</fo:table-body>
+		</fo:table>
+	</xsl:template>
+	
+	<!-- Liste des propriétés baties -->
+	<xsl:template name="lot">
+		<fo:block xsl:use-attribute-sets="titre">Description des lots</fo:block>
+		<fo:table table-layout="fixed">
+			<fo:table-column column-width="10%" />
+			<fo:table-column column-width="10%" />
+			<fo:table-column column-width="10%" />
+			<fo:table-column column-width="10%" />
+			<fo:table-column column-width="10%" />
+			<fo:table-column column-width="10%" />
+			<fo:table-column column-width="40%" />
+			<fo:table-header background-color="yellow" font-weight="bold">
+				<fo:table-row>
+					<fo:table-cell xsl:use-attribute-sets="bordure">
+						<fo:block>
+							Numéro invariant
+						</fo:block>
+					</fo:table-cell>
+					<fo:table-cell xsl:use-attribute-sets="bordure">
+						<fo:block>
+							Numéro de lot
+						</fo:block>
+					</fo:table-cell>
+					<fo:table-cell xsl:use-attribute-sets="bordure">
+						<fo:block>
+							Parts
+						</fo:block>
+					</fo:table-cell>
+					<fo:table-cell xsl:use-attribute-sets="bordure">
+						<fo:block>
+							Logement
+						</fo:block>
+					</fo:table-cell>
+					<fo:table-cell xsl:use-attribute-sets="bordure">
+						<fo:block>
+							Dépendance
+						</fo:block>
+					</fo:table-cell>
+					<fo:table-cell xsl:use-attribute-sets="bordure">
+						<fo:block>
+							Local commercial
+						</fo:block>
+					</fo:table-cell>
+					<fo:table-cell xsl:use-attribute-sets="bordure">
+						<fo:block>
+							Proprietaire
+						</fo:block>
+					</fo:table-cell>
+				</fo:table-row>
+			</fo:table-header>
+			<fo:table-body>
+				<xsl:for-each select="lots/Lot">
+					<fo:table-row>
+						<!-- Adresses des propriétés -->
+						<fo:table-cell xsl:use-attribute-sets="bordure">
+							<fo:block>
+								<!--  invar -->
+								<xsl:value-of select="Propriete/@invar" />
+							</fo:block>
+						</fo:table-cell>
+						<fo:table-cell xsl:use-attribute-sets="bordure">
+							<fo:block>
+								<xsl:value-of select="@lotId" />
+							</fo:block>
+						</fo:table-cell>
+						<fo:table-cell xsl:use-attribute-sets="bordure">
+							<fo:block>
+								<xsl:value-of select="@numerateur" />/<xsl:value-of select="@denominateur" />
+							</fo:block>
+						</fo:table-cell>
+						<fo:table-cell xsl:use-attribute-sets="bordure">
+							<fo:block font-size="6pt">
+								<xsl:value-of select="Propriete/@cconlc" />
+							</fo:block>
+						</fo:table-cell>
+						<fo:table-cell xsl:use-attribute-sets="bordure">
+							<fo:block>
+								<xsl:value-of select="Propriete/@cconad" />
+							</fo:block>
+						</fo:table-cell>
+						<fo:table-cell xsl:use-attribute-sets="bordure">
+							<fo:block>
+								<xsl:value-of select="Propriete/@ccocac" />
+							</fo:block>
+						</fo:table-cell>
+						<fo:table-cell xsl:use-attribute-sets="bordure">
+							<fo:block>
+								<!--  Proprietaire -->
+								<xsl:call-template name="proprietaire" />
+							</fo:block>					
+						</fo:table-cell>
+					</fo:table-row>
+				</xsl:for-each>
+			</fo:table-body>
+		</fo:table>
+	</xsl:template>
+	
+
+</xsl:stylesheet>

--- a/cadastrapp/src/main/resources/xsl/lots.xsl
+++ b/cadastrapp/src/main/resources/xsl/lots.xsl
@@ -70,8 +70,8 @@
 			<xsl:call-template name="entete" />
 		</xsl:if>
 			
-		<!-- liste des proprietaires d'un compte communal -->
-		<xsl:if test="lots">
+		<!-- liste des Lot si  au moins un lot -->
+		<xsl:if test="lots/Lot">
 			<xsl:call-template name="lot" />
 		</xsl:if>
 					

--- a/cadastrapp/src/main/resources/xsl/relevePropriete.xsl
+++ b/cadastrapp/src/main/resources/xsl/relevePropriete.xsl
@@ -76,20 +76,20 @@
 			</xsl:if>
 			
 			<!-- liste des proprietes baties d'un compte communal -->
-			<xsl:if test="proprietesBaties/proprieteBatie">
+			<xsl:if test="proprietesBaties/proprietes">
 				<xsl:call-template name="proprietesBaties" />
 				
-				<xsl:if test="impositionBatie">
+				<xsl:if test="proprietesBaties/imposition">
 					<fo:block>&#160;</fo:block>
 					<xsl:call-template name="revenuImposable" />
 				</xsl:if>
 			</xsl:if>
 			
 			<!-- liste des proprietes non baties d'un compte communal -->
-			<xsl:if test="proprietesNonBaties/proprieteNonBatie">
+			<xsl:if test="proprietesNonBaties/proprietes">
 				<xsl:call-template name="proprietesNonBaties" />
 				
-				<xsl:if test="impositionNonBatie">
+				<xsl:if test="proprietesNonBaties/imposition">
 					<fo:block>&#160;</fo:block>
 					<xsl:call-template name="revenuImposableNonBaties" />
 				</xsl:if>
@@ -352,7 +352,7 @@
 				</fo:table-row>
 			</fo:table-header>
 			<fo:table-body>
-				<xsl:for-each select="proprietesBaties/proprieteBatie">
+				<xsl:for-each select="proprietesBaties/proprietes/propriete">
 					<fo:table-row>
 						<!-- Adresses des propriétés -->
 						<fo:table-cell xsl:use-attribute-sets="bordure">
@@ -606,7 +606,7 @@
 					</fo:table-cell>
 					<fo:table-cell>
 						<fo:block padding-top="5pt" text-align="center">
-							<xsl:value-of select="format-number(impositionBatie/@revenuImposable, '### ##0,00', 'euro')" /> €
+							<xsl:value-of select="format-number(proprietesBaties/imposition/@revenuImposable, '### ##0,00', 'euro')" /> €
 						</fo:block>
 					</fo:table-cell>
 					<fo:table-cell>
@@ -624,10 +624,10 @@
 					</fo:table-cell>
 					<fo:table-cell text-align="center">
 						<fo:block>
-							<xsl:value-of select="format-number(impositionBatie/@communeRevenuExonere, '### ##0,00', 'euro')" /> €
+							<xsl:value-of select="format-number(proprietesBaties/imposition/@communeRevenuExonere, '### ##0,00', 'euro')" /> €
 						</fo:block>
 						<fo:block>
-							<xsl:value-of select="format-number(impositionBatie/@communeRevenuImposable, '### ##0,00', 'euro')" /> €
+							<xsl:value-of select="format-number(proprietesBaties/imposition/@communeRevenuImposable, '### ##0,00', 'euro')" /> €
 						</fo:block>
 					</fo:table-cell>
 					<fo:table-cell>
@@ -645,10 +645,10 @@
 					</fo:table-cell>
 					<fo:table-cell text-align="center">
 						<fo:block>
-							<xsl:value-of select="format-number(impositionBatie/@groupementCommuneRevenuExonere, '### ##0,00', 'euro')" /> €
+							<xsl:value-of select="format-number(proprietesBaties/imposition/@groupementCommuneRevenuExonere, '### ##0,00', 'euro')" /> €
 						</fo:block>
 						<fo:block>
-							<xsl:value-of select="format-number(impositionBatie/@groupementCommuneRevenuImposable, '### ##0,00', 'euro')" /> €
+							<xsl:value-of select="format-number(proprietesBaties/imposition/@groupementCommuneRevenuImposable, '### ##0,00', 'euro')" /> €
 						</fo:block>
 					</fo:table-cell>
 					<fo:table-cell>
@@ -666,10 +666,10 @@
 					</fo:table-cell>
 					<fo:table-cell text-align="center">
 						<fo:block>
-							<xsl:value-of select="format-number(impositionBatie/@departementRevenuExonere, '### ##0,00', 'euro')" /> €
+							<xsl:value-of select="format-number(proprietesBaties/imposition/@departementRevenuExonere, '### ##0,00', 'euro')" /> €
 						</fo:block>
 						<fo:block>
-							<xsl:value-of select="format-number(impositionBatie/@departementRevenuImposable, '### ##0,00', 'euro')" /> €
+							<xsl:value-of select="format-number(proprietesBaties/imposition/@departementRevenuImposable, '### ##0,00', 'euro')" /> €
 						</fo:block>
 					</fo:table-cell>
 				</fo:table-row>
@@ -818,7 +818,7 @@
 				</fo:table-row>
 			</fo:table-header>
 			<fo:table-body>
-				<xsl:for-each select="proprietesNonBaties/proprieteNonBatie">
+				<xsl:for-each select="proprietesNonBaties/proprietes/propriete">
 					<fo:table-row>
 						<fo:table-cell xsl:use-attribute-sets="bordure">
 							<fo:block>
@@ -980,7 +980,7 @@
 					</fo:table-cell>
 					<fo:table-cell>
 						<fo:block padding-top="5pt">
-							<xsl:value-of select="impositionNonBatie/@surface" /> CA
+							<xsl:value-of select="proprietesNonBaties/imposition/@surface" /> CA
 						</fo:block>
 					</fo:table-cell>
 					<fo:table-cell>
@@ -990,7 +990,7 @@
 					</fo:table-cell>
 					<fo:table-cell>
 						<fo:block padding-top="5pt">
-							<xsl:value-of select="format-number(impositionNonBatie/@revenuImposable, '### ##0,00', 'euro')" /> €
+							<xsl:value-of select="format-number(proprietesNonBaties/imposition/@revenuImposable, '### ##0,00', 'euro')" /> €
 						</fo:block>
 					</fo:table-cell>
 					<fo:table-cell>
@@ -1008,10 +1008,10 @@
 					</fo:table-cell>
 					<fo:table-cell  text-align="center">
 						<fo:block>
-							<xsl:value-of select="format-number(impositionNonBatie/@communeRevenuExonere, '### ##0,00', 'euro')" /> €
+							<xsl:value-of select="format-number(proprietesNonBaties/imposition/@communeRevenuExonere, '### ##0,00', 'euro')" /> €
 						</fo:block>
 						<fo:block>
-							<xsl:value-of select="format-number(impositionNonBatie/@communeRevenuImposable, '### ##0,00', 'euro')" /> €
+							<xsl:value-of select="format-number(proprietesNonBaties/imposition/@communeRevenuImposable, '### ##0,00', 'euro')" /> €
 						</fo:block>
 					</fo:table-cell>
 					<fo:table-cell>
@@ -1029,10 +1029,10 @@
 					</fo:table-cell>
 					<fo:table-cell text-align="center">
 						<fo:block>
-							<xsl:value-of select="format-number(impositionNonBatie/@groupementCommuneRevenuExonere, '### ##0,00', 'euro')" /> €
+							<xsl:value-of select="format-number(proprietesNonBaties/imposition/@groupementCommuneRevenuExonere, '### ##0,00', 'euro')" /> €
 						</fo:block>
 						<fo:block>
-							<xsl:value-of select="format-number(impositionNonBatie/@groupementCommuneRevenuImposable, '### ##0,00', 'euro')" /> €
+							<xsl:value-of select="format-number(proprietesNonBaties/imposition/@groupementCommuneRevenuImposable, '### ##0,00', 'euro')" /> €
 						</fo:block>
 					</fo:table-cell>
 					<fo:table-cell>
@@ -1050,15 +1050,15 @@
 					</fo:table-cell>
 					<fo:table-cell text-align="center">
 						<fo:block>
-							<xsl:value-of select="format-number(impositionNonBatie/@departementRevenuExonere, '### ##0,00', 'euro')" /> €
+							<xsl:value-of select="format-number(proprietesNonBaties/imposition/@departementRevenuExonere, '### ##0,00', 'euro')" /> €
 						</fo:block>
 						<fo:block>
-							<xsl:value-of select="format-number(impositionNonBatie/@departementRevenuImposable, '### ##0,00', 'euro')" /> €
+							<xsl:value-of select="format-number(proprietesNonBaties/imposition/@departementRevenuImposable, '### ##0,00', 'euro')" /> €
 						</fo:block>
 					</fo:table-cell>
 					<fo:table-cell>
 						<fo:block padding-top="5pt">
-							MAJ POS : <xsl:value-of select="format-number(impositionNonBatie/@majorationTerraion, '### ##0,00', 'euro')" /> €
+							MAJ POS : <xsl:value-of select="format-number(proprietesNonBaties/imposition/@majorationTerraion, '### ##0,00', 'euro')" /> €
 						</fo:block>
 					</fo:table-cell>
 				</fo:table-row>

--- a/cadastrapp/src/main/resources/xsl/releveProprieteMinimal.xsl
+++ b/cadastrapp/src/main/resources/xsl/releveProprieteMinimal.xsl
@@ -118,16 +118,16 @@
 			</xsl:if>
 			
 			<!-- liste des proprietes baties d'un compte communal -->
-			<xsl:if test="proprietesBaties/proprieteBatie">
+			<xsl:if test="proprietesBaties/proprietes/propriete">
 				<xsl:call-template name="proprietesBaties" />
 			</xsl:if>
 			
 			<!-- liste des proprietes non baties d'un compte communal -->
-			<xsl:if test="proprietesNonBaties/proprieteNonBatie">
+			<xsl:if test="proprietesNonBaties/proprietes/propriete">
 				<xsl:call-template name="proprietesNonBaties" />			
 			</xsl:if>
 			
-			<xsl:if test="impositionNonBatie">
+			<xsl:if test="proprietesNonBaties/imposition">
 				<xsl:call-template name="revenuImposableNonBaties" />
 			</xsl:if>
 		</xsl:for-each>
@@ -460,7 +460,7 @@
 
 	<!-- Designation des proprietes -->
 	<xsl:template name="proprietesBatiesValue">
-		<xsl:for-each select="proprietesBaties/proprieteBatie">
+		<xsl:for-each select="proprietesBaties/proprietes/propriete">
 			<fo:table-row>
 				<fo:table-cell xsl:use-attribute-sets="bordure-values">
 					<fo:block>
@@ -545,7 +545,7 @@
 
 
 	<xsl:template name="proprietesNonBatiesValues">
-		<xsl:for-each select="proprietesNonBaties/proprieteNonBatie">
+		<xsl:for-each select="proprietesNonBaties/proprietes/propriete">
 			<fo:table-row height="20pt">
 				<fo:table-cell xsl:use-attribute-sets="bordure-values">
 					<fo:block>
@@ -636,12 +636,12 @@
 					</fo:table-cell>
 					<fo:table-cell>
 						<fo:block padding-top="5pt">
-							<xsl:value-of select="impositionNonBatie/@surface" /> CA
+							<xsl:value-of select="proprietesNonBaties/imposition/@surface" /> CA
 						</fo:block>
 					</fo:table-cell>
 					<fo:table-cell>
 						<fo:block padding-top="5pt">
-							MAJ POS : <xsl:value-of select="impositionNonBatie/@majorationTerraion" />
+							MAJ POS : <xsl:value-of select="proprietesNonBaties/imposition/@majorationTerraion" />
 						</fo:block>
 					</fo:table-cell>
 				</fo:table-row>

--- a/script/commun/index.sql
+++ b/script/commun/index.sql
@@ -19,6 +19,11 @@ CREATE INDEX idxproprietairenomnaissance ON #schema_cadastrapp.proprietaire (UPP
 CREATE INDEX idxproprietaireparcellecomptecommunal ON #schema_cadastrapp.proprietaire_parcelle (comptecommunal);
 CREATE INDEX idxproprietaireparcelleparcelle ON #schema_cadastrapp.proprietaire_parcelle (parcelle);
 
+-- CO_Proprietaire_parcelle
+CREATE INDEX idxcoproprietaireparcellecomptecommunal ON #schema_cadastrapp.co_propriete_parcelle (comptecommunal);
+CREATE INDEX idxcoproprietaireparcelleparcelle ON #schema_cadastrapp.co_propriete_parcelle (parcelle);
+CREATE INDEX idxcoproprietaireparcelleparcellecomptecommunal ON #schema_cadastrapp.co_propriete_parcelle (parcelle, comptecommunal);
+
 -- Parcelle
 CREATE INDEX idxparcellecgocommune ON #schema_cadastrapp.parcelle (cgocommune);
 CREATE INDEX idxparcelleparcelle ON #schema_cadastrapp.parcelle (parcelle);
@@ -39,7 +44,8 @@ CREATE INDEX idxparcelledetailscgocommuneparcelle ON #schema_cadastrapp.parcelle
 -- ProprieteBatie
 CREATE INDEX idxproprietebatiecomptecommunal ON #schema_cadastrapp.proprietebatie (comptecommunal);
 CREATE INDEX idxproprietebatiecgocommune ON #schema_cadastrapp.proprietebatie (cgocommune);
-CREATE INDEX idxproprietebatiednubat ON #schema_cadastrapp.proprietebatie (dnubat);
+CREATE INDEX idxproprietebatieparcellednubat ON #schema_cadastrapp.proprietebatie (parcelle, dnubat);
+CREATE INDEX idxproprietebatieparcelle ON #schema_cadastrapp.proprietebatie (parcelle);
 
 -- ProprieteNonbatie
 CREATE INDEX idxproprietenonbatieparcelle ON #schema_cadastrapp.proprietenonbatie (parcelle);
@@ -47,10 +53,15 @@ CREATE INDEX idxproprietenonbatiecgocommune ON #schema_cadastrapp.proprietenonba
 
 -- ProprieteNonbatieSufExo
 CREATE INDEX idxproprietenonbatiesufexoparcelle ON #schema_cadastrapp.proprietenonbatiesufexo (parcelle);
-CREATE INDEX idxproprietenonbatiesufexocgocommune ON #schema_cadastrapp.proprietenonbatiesufexo (cgocommune);
+CREATE INDEX idxproprietenonbatiesufexocgocommune ON #schema_cadastrapp.proprietenonbatiesufexo (cgocommune, id_local);
 
 -- Section
 CREATE INDEX idxsectioncgocommune ON #schema_cadastrapp.section (cgocommune);
 CREATE INDEX idxsectioncgocommuneccosec ON #schema_cadastrapp.section (cgocommune, ccosec);
 
+-- Lot
+CREATE INDEX idxlotlots ON #schema_cadastrapp.lot (id_local);
+
+-- Dependance
+CREATE INDEX idxdescdependanceinvar ON #schema_cadastrapp.descdependance (invar);
 


### PR DESCRIPTION
Ajout deux deux boutons d'export, permettant d'exporter les lots de copropriété en format CSV ou PDF.

Pour faire cette évolution, la structure du model d'objet (côte java) a été revu pour les exports, il y a donc des modifications techniques aussi sur les relevés de propriétés (pour éviter la duplication de code) mais aucune modification fonctionnelle sur les RP.