### PR TITLE
Ajout de la forme juridique au libelle du propriétaire

### DIFF
--- a/script/arcopole/views/arcopoleProprietaire.sql
+++ b/script/arcopole/views/arcopoleProprietaire.sql
@@ -114,7 +114,7 @@ CREATE MATERIALIZED VIEW #schema_cadastrapp.proprietaire as
 			id_prop as  comptecommunal,
 			(CASE
 					WHEN gtoper = ''1'' THEN COALESCE(rtrim(dqualp),'''')||'' ''||COALESCE(rtrim(dnomus),'''')||'' ''||COALESCE(rtrim(dprnus),'''')
-					WHEN gtoper = ''2'' THEN rtrim(ddenom)
+					WHEN gtoper = ''2'' THEN rtrim(ddenom)||'' (''||rtrim(dformjur)||'')''
 				END) AS app_nom_usage,
 			(CASE
 					WHEN gtoper = ''1'' THEN COALESCE(rtrim(dqualp),'''')||'' ''||REPLACE(rtrim(ddenom),''/'','' '')

--- a/script/qgis/views/qgisProprietaire.sql
+++ b/script/qgis/views/qgisProprietaire.sql
@@ -113,7 +113,7 @@ CREATE MATERIALIZED VIEW #schema_cadastrapp.proprietaire AS
 			pqgis.comptecommunal, 
 			CASE
 				WHEN gtoper = ''1'' THEN COALESCE(rtrim(dqualp),'''')||'' ''||COALESCE(rtrim(dnomus),'''')||'' ''||COALESCE(rtrim(dprnus),'''')
-				WHEN gtoper = ''2'' THEN rtrim(ddenom)
+				WHEN gtoper = ''2'' THEN rtrim(ddenom)||'' (''||rtrim(pqgis.dformjur)||'')''
 			END AS app_nom_usage,
 			CASE
 				WHEN gtoper = ''1'' THEN COALESCE(rtrim(dqualp),'''')||'' ''||REPLACE(rtrim(ddenom),''/'','' '')


### PR DESCRIPTION
Actuellement dans le cas d'une entreprise, la forme juridique n'apparait pas.

Ce patch permet de la faire apparaitre entre parenthèse dans le libelle.

Cette information nous a été demandé par l'une de nos communes.