### PR TITLE
Adapt views after 3liz/QgisCadastrePlugin@7c48ec5 (cf #400)

### DIFF
--- a/script/qgis/views/qgisParcelle.sql
+++ b/script/qgis/views/qgisParcelle.sql
@@ -110,7 +110,7 @@ CREATE MATERIALIZED VIEW #schema_cadastrapp.parcelledetails AS
 			COALESCE(ltrim(parcelle.dnupla, ''0''),geo_parcelle.tex) as dnupla,
 			COALESCE(parcelle.dcntpa,CAST(geo_parcelle.supf AS integer)) as dcntpa,
 			parcelle.dsrpar,
-			concat(substr(parcelle.jdatat::text,9,2),''/'',substr(parcelle.jdatat::text,6,2),''/'',substr(parcelle.jdatat::text,1,4)) as jdatat,
+			concat(substr(parcelle.jdatat::text,1,2),''/'',substr(parcelle.jdatat::text,3,2),''/'',substr(parcelle.jdatat::text,5,4)) as jdatat,
 			parcelle.dreflf,
 			parcelle.gpdl,
 			parcelle.cprsecr,

--- a/script/qgis/views/qgisProprietaire.sql
+++ b/script/qgis/views/qgisProprietaire.sql
@@ -100,7 +100,7 @@ CREATE MATERIALIZED VIEW #schema_cadastrapp.proprietaire AS
 			pqgis.dqualp,
 			rtrim(pqgis.dnomlp) as dnomlp,
 			rtrim(pqgis.dprnlp) as dprnlp,
-			COALESCE(to_char(pqgis.jdatnss, ''DD/MM/YYYY''), '''') as jdatnss,
+			COALESCE(pqgis.jdatnss, '''') as jdatnss,
 			pqgis.dldnss,
 			pqgis.epxnee,
 			rtrim(pqgis.dnomcp) as dnomcp,

--- a/script/qgis/views/qgisProprieteBatie.sql
+++ b/script/qgis/views/qgisProprieteBatie.sql
@@ -49,7 +49,7 @@ CREATE MATERIALIZED VIEW #schema_cadastrapp.proprietebatie AS
 			ltrim(l.ccopre) as ccopre,
 			ltrim(l.ccosec) as ccosec,
 			ltrim(l.dnupla, ''0'') as dnupla,
-			COALESCE(to_char(l.jdatat, ''DD/MM/YYYY''), '''') as jdatat,
+			COALESCE(l.jdatat, '''') as jdatat,
 			v.voie,
 			ltrim(l.dnvoiri, ''0'') as dnvoiri,
 			l00.dindic,

--- a/script/qgis/views/qgisProprieteNonBatie.sql
+++ b/script/qgis/views/qgisProprieteNonBatie.sql
@@ -38,7 +38,7 @@ CREATE MATERIALIZED VIEW #schema_cadastrapp.proprietenonbatie AS
 	FROM dblink('host=#DBHost_qgis port=#DBPort_qgis dbname=#DBName_qgis user=#DBUser_qgis password=#DBpasswd_qgis'::text, 
 		'select 
 			suf.suf as id_local,
-			COALESCE(to_char(p.jdatat, ''DD/MM/YYYY''), '''') as jdatat,
+			COALESCE(p.jdatat, '''') as jdatat,
 			p.comptecommunal,
 			p.ccodep || p.ccodir ||	p.ccocom as cgocommune,
 			ltrim(p.ccopre) as ccopre,


### PR DESCRIPTION
jdatat and jdatnss are now text fields.

I've been able to create the 3 views with this change, and the jdatat/jdatnss fields have valid dates or empty values, as expected.

```
select count(*) from cad2018.proprietaire where jdatnss != '';
7920508
select count(*) from cad2018.proprietaire where jdatnss = '';
824579
select count(*) from cad2018.proprietaire where jdatnss not similar to '\d{2}/\d{2}/\d{4}' and jdatnss != '';
0
select count(*) from cad2018.proprietebatie where jdatat != '';
8545239
select count(*) from cad2018.proprietebatie where jdatat = '';
2210001
select count(*) from cad2018.proprietebatie where jdatat not similar to '\d{8}' and  jdatat != '' ;
0
```
