### PR TITLE
Suppression des couches internes lors de la fermeture/destruction de l'addon (#404)

### DIFF
--- a/addons/cadastrapp/js/main.js
+++ b/addons/cadastrapp/js/main.js
@@ -116,6 +116,7 @@ GEOR.Addons.Cadastrapp = Ext.extend(GEOR.Addons.Base, {
                     this.item.setChecked(true, true);
                     GEOR.Addons.Cadastre.visible = true;
                     GEOR.Addons.Cadastre.addWMSLayer(WMSSetting);
+                    this.map.addLayer(GEOR.Addons.Cadastre.WFSLayer);
                     GEOR.Addons.Cadastre.addPopupOnhover(this.options.popup);
                     var maxX =  window.innerWidth;
                     this.window.setPagePosition(maxX * 0.3 ,0);

--- a/addons/cadastrapp/js/main.js
+++ b/addons/cadastrapp/js/main.js
@@ -144,6 +144,8 @@ GEOR.Addons.Cadastrapp = Ext.extend(GEOR.Addons.Base, {
                         GEOR.Addons.Cadastre.WMSLayer.destroy();
                         GEOR.Addons.Cadastre.WMSLayer = null;
                     }
+                    // Remove WFS layer
+                    this.map.removeLayer(GEOR.Addons.Cadastre.WFSLayer);
 
                     // Remove all windows
                     if(GEOR.Addons.Cadastre.popup){

--- a/addons/cadastrapp/js/menu.js
+++ b/addons/cadastrapp/js/menu.js
@@ -529,6 +529,9 @@ GEOR.Addons.Cadastre.Menu = Ext.extend(Ext.util.Observable, {
         GEOR.Addons.Cadastre.WFSLayer.destroy();
         GEOR.Addons.Cadastre.WFSLayer = null;
 
+        // Remove internal layer
+        this.map.removeLayer(this.map.getLayersByName("__georchestra_cadastrapps")[0]);
+
         this.map = null;
     },
 

--- a/addons/cadastrapp/js/menu.js
+++ b/addons/cadastrapp/js/menu.js
@@ -524,7 +524,8 @@ GEOR.Addons.Cadastre.Menu = Ext.extend(Ext.util.Observable, {
 
         // Remove WFSLayer
         GEOR.Addons.Cadastre.WFSLayer.removeAllFeatures();
-        this.map.removeLayer(GEOR.Addons.Cadastre.WFSLayer);
+        if (this.map.getLayer(GEOR.Addons.Cadastre.WFSLayer))
+            this.map.removeLayer(GEOR.Addons.Cadastre.WFSLayer);
         GEOR.Addons.Cadastre.WFSLayer.destroy();
         GEOR.Addons.Cadastre.WFSLayer = null;
 

--- a/addons/cadastrapp/js/selectFeature.js
+++ b/addons/cadastrapp/js/selectFeature.js
@@ -39,8 +39,6 @@ GEOR.Addons.Cadastre.createLayer = function(styleParams) {
 
     GEOR.Addons.Cadastre.WFSLayer.selectControl = new OpenLayers.Control.SelectFeature([GEOR.Addons.Cadastre.WFSLayer]);
 
-    // ajout de la couche à la carte
-    GeoExt.MapPanel.guess().map.addLayer(GEOR.Addons.Cadastre.WFSLayer);
     GeoExt.MapPanel.guess().map.addControl(GEOR.Addons.Cadastre.WFSLayer.selectControl);
        
     //TODO check see ZIndex


### PR DESCRIPTION
Testé dans les cas suivants:
* chargement de l'addon a l'ouverture de la visionneuse
* chargement de l'addon a posteriori via le menu outils
* fermeture de la barre d'outil puis réouverture
* désactivation de l'addon avec la barre d'outil ouverte
* désactivation de l'addon avec la barre d'outil fermée

dans chacun des cas, les bonnes couches semblent chargées/actives, et le nettoyage est correctement fait a la fermeture de la barre d'outil (la couche cadastre et celle des selections ne sont plus visibles) et a la désactivation de l'outil (les 3 couches sont supprimées)