### PR TITLE
Add index on v_parcelle_surfc

### DIFF
--- a/script/commun/index.sql
+++ b/script/commun/index.sql
@@ -42,6 +42,9 @@ CREATE INDEX idxparcelledetailsccopre ON #schema_cadastrapp.parcelledetails (cco
 CREATE INDEX idxparcelledetailsdvoilib ON #schema_cadastrapp.parcelledetails (dvoilib);
 CREATE INDEX idxparcelledetailscgocommuneparcelle ON #schema_cadastrapp.parcelledetails (cgocommune, parcelle);
 
+-- v_parcelle_surfc
+CREATE INDEX idxvparcellesurfcparcelle ON #schema_cadastrapp.v_parcelle_surfc (parcelle);
+
 -- ProprieteBatie
 CREATE INDEX idxproprietebatiecomptecommunal ON #schema_cadastrapp.proprietebatie (comptecommunal);
 CREATE INDEX idxproprietebatiecgocommune ON #schema_cadastrapp.proprietebatie (cgocommune);


### PR DESCRIPTION
Devrait améliorer un chouia la seule utilisation actuelle de `v_parcelle_surfc` ici https://github.com/georchestra/cadastrapp/blob/master/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/InfoBulleController.java#L87
```
 cad2018 | idxvparcellesurfcparcelle | index | cadastrapp | v_parcelle_surfc | 557 MB |
 cad2018 | v_parcelle_surfc | materialized view | cadastrapp | 852 MB |
```