### PR TITLE
Migrate to orgs (fixes #412)

### DIFF
--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/providers/PreRequestFilter.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/providers/PreRequestFilter.java
@@ -22,8 +22,10 @@ public class PreRequestFilter implements ContainerRequestFilter {
 	public void filter(ContainerRequestContext requestContext) throws IOException {
 			
 		String rolesList = requestContext.getHeaderString("sec-roles");
+		String org = requestContext.getHeaderString("sec-org");
 		String userName = requestContext.getHeaderString("sec-username");
 		MDC.put("user", userName);
+		MDC.put("org", org);
 		MDC.put("roles", rolesList);
 		MDC.put("uri", requestContext.getUriInfo().getPath());	
 		

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/CadController.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/CadController.java
@@ -154,7 +154,7 @@ public class CadController {
 		// get org in header
 		String orgString = headers.getHeaderString("sec-org");
 		
-		logger.debug("Check user " + usernameString + " with org : "+ orgString + "geographical limitation ");
+		logger.debug("Check user '" + usernameString + "' with org '"+ orgString + "' geographical limitation ");
 		if(orgString!=null){
 			// get commune list in database corresponding to this org
 			StringBuilder queryBuilder = new StringBuilder();
@@ -215,7 +215,7 @@ public class CadController {
 			}			
 		}
 		else{
-			logger.error("Connected user but no sec-org header, something is wrong");
+			logger.error("User authenticated as '" + usernameString + "' but no sec-org header, something is wrong");
 		}
 
 		return queryFilter.toString();

--- a/cadastrapp/src/main/resources/logback.xml
+++ b/cadastrapp/src/main/resources/logback.xml
@@ -30,7 +30,7 @@
 	<appender name="FILE" class="ch.qos.logback.core.FileAppender">
 		<file>/tmp/cadastrapp.log</file>
 		<encoder>
-			<pattern>%d [%thread] %-5level /%X{uri} - %X{user:-nouser} - %X{roles:-norole} -%logger{36} - %msg%n</pattern>
+			<pattern>%d [%thread] %-5level /%X{uri} - %X{user:-nouser} - %X{org:-noorg} - %X{roles:-norole} -%logger{36} - %msg%n</pattern>
 		</encoder>
 	</appender>
 


### PR DESCRIPTION
C'est un POC rapide et ne résoud pas les autres interrogations sur le comportement par défaut a avoir quand aucun filtrage n'a lieu, mais ca marche ici, le header `sec-org` ne peut avoir actuellement qu'une valeur donc plus besoin du séparateur/parsing. J'ai amélioré un peu le logging au passage.

Test non connecté/authentifié:
```
$curl http://localhost:8480/cadastrapp/services/getCommune?libcom=maza
[{"cgocommune":"070154","libcom":"MAZAN-L ABBAYE","libcom_min":"Mazan-L Abbaye"},{"cgocommune":"630219","libcom":"MAZAYE","libcom_min":"Mazaye"}]
```
Test en fakant un org ayant cette limitation (ROLE_EL est un reste historique....):
```
[db:5432] cadastrapp@cadastrapp=> select * from cad2018.groupe_autorisation where idgroup='ROLE_EL_COM_MAZAYES';
  id   |       idgroup       | cgocommune | ccodep 
-------+---------------------+------------+--------
 13742 | ROLE_EL_COM_MAZAYES | 630219     | NULL
```
le test limite bien comme prévu:
```
$curl -Hsec-username:testadmin -H sec-org:COM_MAZAYES http://localhost:8480/cadastrapp/services/getCommune?libcom=maza
[{"cgocommune":"630219","libcom":"MAZAYE","libcom_min":"Mazaye"}]
```
et dans le log:
```
/getCommune - testadmin - COM_MAZAYES - norole -o.g.c.providers.PreRequestFilter - Parameter list : {libcom=[maza]}
/getCommune - testadmin - COM_MAZAYES - norole -o.g.cadastrapp.service.CadController - Check user 'testadmin' with org 'COM_MAZAYES' geographical limitation
/getCommune - testadmin - COM_MAZAYES - norole -o.g.cadastrapp.service.CadController - List to String :  WHERE idgroup IN (?)
/getCommune - testadmin - COM_MAZAYES - norole -o.g.cadastrapp.service.CadController - User have geographical limitation on zip code : [630219]
/getCommune - testadmin - COM_MAZAYES - norole -o.g.cadastrapp.service.CadController - User have geographical limitation on dep : []
/getCommune - testadmin - COM_MAZAYES - norole -o.g.cadastrapp.service.CadController - List to String : '630219'
```
