### PR TITLE
Gestion correcte des couches lors de la géneration de BP

### DIFF
--- a/cadastrapp/src/main/resources/cadastrapp.properties
+++ b/cadastrapp/src/main/resources/cadastrapp.properties
@@ -63,6 +63,17 @@ cadastre.wms.layer.name=qgis:geo_parcelle
 cadastre.wms.username=
 cadastre.wms.password=
 
+# Here you can configure the layer used to generate the parcel selection on BP
+# Note that it must support SLD_BODY WMS param
+parcelle.wms.url=https://opendata.agglo-lepuyenvelay.fr/geoserver/wms
+parcelle.wms.layer.name=pci:geo_parcelle
+# The parcel identifier field
+parcelle.id=geo_parcelle
+# only used when wms service need authentification
+# if empty no authentification is used
+parcelle.wms.username=
+parcelle.wms.password=
+
 cadastre.wfs.url=https://georchestra.example.org/geoserver/wfs
 cadastre.wfs.layer.name=qgis:geo_parcelle
 # only used when wfs service need authentification


### PR DESCRIPTION
Cette PR permet de différencier la couche "fond cadastral" et la couche de sélection de parcelle lors de la génération du bordereau parcellaire.

Ainsi on peut avoir sur le BP 3 couches distinctes : 

- Fond OSM (baseMap)
- Fond cadastral (WMS/WMTS)
- Parcelle sélectionnée (WMS avec support SLD_BODY)

Ceci avait été évoqué ici : https://github.com/georchestra/cadastrapp/issues/403

Attention : des configuration supplémentaires sont nécessaires dans le cadastrapp.properties