### PR TITLE
PR pour l'issue #388

### DIFF
--- a/addons/cadastrapp/js/main.js
+++ b/addons/cadastrapp/js/main.js
@@ -91,6 +91,7 @@ GEOR.Addons.Cadastrapp = Ext.extend(GEOR.Addons.Base, {
         GEOR.Addons.Cadastre.result.owner=[];
         GEOR.Addons.Cadastre.result.owner.window;
 
+        GEOR.Addons.Cadastre.styles=this.options.style;
         GEOR.Addons.Cadastre.createLayer(this.options.style);
         
         GEOR.wmc.events.on("aftercontextrestore", GEOR.Addons.Cadastre.restoreLayersOnClear, this);
@@ -192,6 +193,11 @@ GEOR.Addons.Cadastrapp = Ext.extend(GEOR.Addons.Base, {
                     if(GEOR.Addons.Cadastre.printLotsWindow){
                     	GEOR.Addons.Cadastre.printLotsWindow.close();
                     	GEOR.Addons.Cadastre.printLotsWindow=null;
+                    }
+                    
+                    if(GEOR.Addons.Cadastre.preferencesWindow){
+                        GEOR.Addons.Cadastre.preferencesWindow.close();
+                        GEOR.Addons.Cadastre.preferencesWindow=null;
                     }
                 },
                 scope: this

--- a/addons/cadastrapp/js/main.js
+++ b/addons/cadastrapp/js/main.js
@@ -91,8 +91,22 @@ GEOR.Addons.Cadastrapp = Ext.extend(GEOR.Addons.Base, {
         GEOR.Addons.Cadastre.result.owner=[];
         GEOR.Addons.Cadastre.result.owner.window;
 
-        GEOR.Addons.Cadastre.styles=this.options.style;
-        GEOR.Addons.Cadastre.createLayer(this.options.style);
+        GEOR.Addons.Cadastre.defaultStyles=this.options.style;
+        // Check if user has style preferences and apply them
+        if(GEOR.ls.get("cadastrapp_style_preference") != null){
+            try {
+                GEOR.Addons.Cadastre.styles=JSON.parse(GEOR.ls.get("cadastrapp_style_preference"));
+            } catch(e) {
+                // If an error occured when parsing data
+                GEOR.Addons.Cadastre.styles=GEOR.Addons.Cadastre.defaultStyles;
+            }
+        }
+        //if nothing stored in localstorage
+        if(typeof GEOR.Addons.Cadastre.styles === "undefined"){
+            GEOR.Addons.Cadastre.styles=GEOR.Addons.Cadastre.defaultStyles;
+        }
+        // Create vectore Layer
+        GEOR.Addons.Cadastre.createLayer(GEOR.Addons.Cadastre.styles);
         
         GEOR.wmc.events.on("aftercontextrestore", GEOR.Addons.Cadastre.restoreLayersOnClear, this);
         GEOR.managelayers.events.on("aftercontextcleared", GEOR.Addons.Cadastre.restoreLayersOnClear, this);

--- a/addons/cadastrapp/js/menu.js
+++ b/addons/cadastrapp/js/menu.js
@@ -430,6 +430,15 @@ GEOR.Addons.Cadastre.Menu = Ext.extend(Ext.util.Observable, {
         buttonTraitementSelectionProprietairesExport.on('click', function() {
             GEOR.Addons.Cadastre.exportOwnerSelectionAsCSV()
         });
+        
+        // sous-menu : préférence
+        var buttonMenuPreference = scrollMenu.add({
+            tooltip : OpenLayers.i18n("cadastrapp.menu.preference"),
+            text : OpenLayers.i18n("cadastrapp.menu.preference")
+        });
+        buttonMenuPreference.on('click', function() {
+            GEOR.Addons.Cadastre.onClickLoadPreferencePanel()
+        });
 
     },
 

--- a/addons/cadastrapp/js/menu.js
+++ b/addons/cadastrapp/js/menu.js
@@ -37,9 +37,9 @@ GEOR.Addons.Cadastre.Menu = Ext.extend(Ext.util.Observable, {
         this.items.push('-');
         this.initSelectionControls(cadastreLayer);
         this.items.push('-');
-        
+
         //init UF button only if option foncier is true in manifest
-        if (GEOR.Addons.Cadastre.UF.isfoncier){
+        if (GEOR.Addons.Cadastre.UF.isfoncier) {
             this.initUFControls(cadastreLayer);
             this.items.push('-');
         }
@@ -137,21 +137,21 @@ GEOR.Addons.Cadastre.Menu = Ext.extend(Ext.util.Observable, {
             var isButtonPressed = false;
 
             switch (geometryType) {
-                case "LineString":
-                    handler = OpenLayers.Handler.Path;
-                    iconCls = "gx-featureediting-cadastrapp-line";
-                    tooltip = OpenLayers.i18n("cadastrapp.create_line");
-                    break;
-                case "Point":
-                    handler = OpenLayers.Handler.Point;
-                    iconCls = "gx-featureediting-cadastrapp-point";
-                    tooltip = OpenLayers.i18n("cadastrapp.create_point");
-                    break;
-                case "Polygon":
-                    handler = OpenLayers.Handler.Polygon;
-                    iconCls = "gx-featureediting-cadastrapp-polygon";
-                    tooltip = OpenLayers.i18n("cadastrapp.create_polygon");
-                    break;
+            case "LineString":
+                handler = OpenLayers.Handler.Path;
+                iconCls = "gx-featureediting-cadastrapp-line";
+                tooltip = OpenLayers.i18n("cadastrapp.create_line");
+                break;
+            case "Point":
+                handler = OpenLayers.Handler.Point;
+                iconCls = "gx-featureediting-cadastrapp-point";
+                tooltip = OpenLayers.i18n("cadastrapp.create_point");
+                break;
+            case "Polygon":
+                handler = OpenLayers.Handler.Polygon;
+                iconCls = "gx-featureediting-cadastrapp-polygon";
+                tooltip = OpenLayers.i18n("cadastrapp.create_polygon");
+                break;
             }
 
             control = new OpenLayers.Control.DrawFeature(layer, handler, options);
@@ -193,13 +193,13 @@ GEOR.Addons.Cadastre.Menu = Ext.extend(Ext.util.Observable, {
      */
     initUFControls : function(layer) {
 
-        var control, handler,  options, action,actionOptions;
+        var control, handler, options, action, actionOptions;
 
         options = {
-                handlerOptions : {
+            handlerOptions : {
                 stopDown : true,
                 stopUp : true
-                }
+            }
         };
 
         handler = OpenLayers.Handler.Point;
@@ -211,43 +211,42 @@ GEOR.Addons.Cadastre.Menu = Ext.extend(Ext.util.Observable, {
         });
 
         actionOptions = {
-                control : control,
-                map : this.map,
-                // button options
-                toggleGroup : 'map',
-                allowDepress : true,
-                tooltip : OpenLayers.i18n("cadastrapp.menu.tooltips.foncier"),
-                iconCls : "gx-featureediting-cadastrapp-parcelle",
-                text : OpenLayers.i18n("cadastrapp.foncier"),
-                iconAlign : 'top',
-                toggleHandler : function(btn, pressed) {
-                    if (pressed) {
-                        
-                        // Close all windows and clean existing feature
-                        GEOR.Addons.Cadastre.WFSLayer.removeAllFeatures();
-                        GEOR.Addons.Cadastre.UF.features=[];
-                        if(GEOR.Addons.Cadastre.result.plot.window){
-                            GEOR.Addons.Cadastre.result.plot.window.close();
-                        }
-                        if(GEOR.Addons.Cadastre.rechercheParcelleWindow){
-                            GEOR.Addons.Cadastre.rechercheParcelleWindow.close();
-                        }
-                        if(GEOR.Addons.Cadastre.proprietaireWindow){
-                            GEOR.Addons.Cadastre.proprietaireWindow.close();
-                        }
-                        if(GEOR.Addons.Cadastre.coProprieteWindow){
-                            GEOR.Addons.Cadastre.coProprieteWindow.close();
-                        }
+            control : control,
+            map : this.map,
+            // button options
+            toggleGroup : 'map',
+            allowDepress : true,
+            tooltip : OpenLayers.i18n("cadastrapp.menu.tooltips.foncier"),
+            iconCls : "gx-featureediting-cadastrapp-parcelle",
+            text : OpenLayers.i18n("cadastrapp.foncier"),
+            iconAlign : 'top',
+            toggleHandler : function(btn, pressed) {
+                if (pressed) {
+
+                    // Close all windows and clean existing feature
+                    GEOR.Addons.Cadastre.WFSLayer.removeAllFeatures();
+                    GEOR.Addons.Cadastre.UF.features = [];
+                    if (GEOR.Addons.Cadastre.result.plot.window) {
+                        GEOR.Addons.Cadastre.result.plot.window.close();
                     }
-                    else{
-                        // Clean existing feature
-                        // For each existing uf feature remove it
-                        Ext.each(GEOR.Addons.Cadastre.UF.features, function(feature) {
-                            GEOR.Addons.Cadastre.WFSLayer.removeFeatures(feature);
-                        });
-                        GEOR.Addons.Cadastre.UF.features=[];
+                    if (GEOR.Addons.Cadastre.rechercheParcelleWindow) {
+                        GEOR.Addons.Cadastre.rechercheParcelleWindow.close();
                     }
+                    if (GEOR.Addons.Cadastre.proprietaireWindow) {
+                        GEOR.Addons.Cadastre.proprietaireWindow.close();
+                    }
+                    if (GEOR.Addons.Cadastre.coProprieteWindow) {
+                        GEOR.Addons.Cadastre.coProprieteWindow.close();
+                    }
+                } else {
+                    // Clean existing feature
+                    // For each existing uf feature remove it
+                    Ext.each(GEOR.Addons.Cadastre.UF.features, function(feature) {
+                        GEOR.Addons.Cadastre.WFSLayer.removeFeatures(feature);
+                    });
+                    GEOR.Addons.Cadastre.UF.features = [];
                 }
+            }
         };
         action = new GeoExt.Action(actionOptions);
         this.items.push(action);
@@ -270,17 +269,17 @@ GEOR.Addons.Cadastre.Menu = Ext.extend(Ext.util.Observable, {
         this.items.push(new Ext.Button(configRechercheParcelle));
 
         // menu : recherche propriétaire
-            var configRechercheProprietaire = {
-                id : 'owner-lookup-button',
-                tooltip : OpenLayers.i18n("cadastrapp.proprietaire"),
-                iconCls : "gx-featureediting-cadastrapp-parcelle",
-                iconAlign : 'top',
-                text : OpenLayers.i18n("cadastrapp.proprietaire"),
-                handler : function() {
-                    GEOR.Addons.Cadastre.onClickRechercheProprietaire(0)
-                }
-            };
-            this.items.push(new Ext.Button(configRechercheProprietaire));
+        var configRechercheProprietaire = {
+            id : 'owner-lookup-button',
+            tooltip : OpenLayers.i18n("cadastrapp.proprietaire"),
+            iconCls : "gx-featureediting-cadastrapp-parcelle",
+            iconAlign : 'top',
+            text : OpenLayers.i18n("cadastrapp.proprietaire"),
+            handler : function() {
+                GEOR.Addons.Cadastre.onClickRechercheProprietaire(0)
+            }
+        };
+        this.items.push(new Ext.Button(configRechercheProprietaire));
 
         // menu : recherche avancée
         var scrollMenu = new Ext.menu.Menu();
@@ -336,49 +335,49 @@ GEOR.Addons.Cadastre.Menu = Ext.extend(Ext.util.Observable, {
             GEOR.Addons.Cadastre.onClickRechercheParcelle(3)
         });
 
-            // sous-menu : recherche proprietaire
-            var scrollMenuRechercheProprietaire = new Ext.menu.Menu();
-            var buttonRechercheProprietaire = scrollMenu.add({
-                id : 'owner-lookup-submenu',
-                tooltip : OpenLayers.i18n("cadastrapp.proprietaire"),
-                text : OpenLayers.i18n("cadastrapp.proprietaire"),
-                menu : scrollMenuRechercheProprietaire
-            });
-            // sous-sous-menu : recherche proprietaire - par nom
-            var buttonRechercheProprietaireNom = scrollMenuRechercheProprietaire.add({
-                tooltip : OpenLayers.i18n("cadastrapp.proprietaire.nom"),
-                text : OpenLayers.i18n("cadastrapp.proprietaire.nom")
-            });
-            buttonRechercheProprietaireNom.on('click', function() {
-                GEOR.Addons.Cadastre.onClickRechercheProprietaire(0)
-            });
+        // sous-menu : recherche proprietaire
+        var scrollMenuRechercheProprietaire = new Ext.menu.Menu();
+        var buttonRechercheProprietaire = scrollMenu.add({
+            id : 'owner-lookup-submenu',
+            tooltip : OpenLayers.i18n("cadastrapp.proprietaire"),
+            text : OpenLayers.i18n("cadastrapp.proprietaire"),
+            menu : scrollMenuRechercheProprietaire
+        });
+        // sous-sous-menu : recherche proprietaire - par nom
+        var buttonRechercheProprietaireNom = scrollMenuRechercheProprietaire.add({
+            tooltip : OpenLayers.i18n("cadastrapp.proprietaire.nom"),
+            text : OpenLayers.i18n("cadastrapp.proprietaire.nom")
+        });
+        buttonRechercheProprietaireNom.on('click', function() {
+            GEOR.Addons.Cadastre.onClickRechercheProprietaire(0)
+        });
 
-            // sous-sous-menu : recherche proprietaire - par compte
-            var buttonRechercheProprietaireCompte = scrollMenuRechercheProprietaire.add({
-                tooltip : OpenLayers.i18n("cadastrapp.proprietaire.compte"),
-                text : OpenLayers.i18n("cadastrapp.proprietaire.compte")
-            });
-            buttonRechercheProprietaireCompte.on('click', function() {
-                GEOR.Addons.Cadastre.onClickRechercheProprietaire(1)
-            });
+        // sous-sous-menu : recherche proprietaire - par compte
+        var buttonRechercheProprietaireCompte = scrollMenuRechercheProprietaire.add({
+            tooltip : OpenLayers.i18n("cadastrapp.proprietaire.compte"),
+            text : OpenLayers.i18n("cadastrapp.proprietaire.compte")
+        });
+        buttonRechercheProprietaireCompte.on('click', function() {
+            GEOR.Addons.Cadastre.onClickRechercheProprietaire(1)
+        });
 
-            // sous-sous-menu : recherche proprietaire - par compte
-            var buttonRechercheProprietaireCompte = scrollMenuRechercheProprietaire.add({
-                tooltip : OpenLayers.i18n("cadastrapp.proprietaire.lot"),
-                text : OpenLayers.i18n("cadastrapp.proprietaire.lot")
-            });
-            buttonRechercheProprietaireCompte.on('click', function() {
-                GEOR.Addons.Cadastre.onClickRechercheProprietaire(2)
-            });
+        // sous-sous-menu : recherche proprietaire - par compte
+        var buttonRechercheProprietaireCompte = scrollMenuRechercheProprietaire.add({
+            tooltip : OpenLayers.i18n("cadastrapp.proprietaire.lot"),
+            text : OpenLayers.i18n("cadastrapp.proprietaire.lot")
+        });
+        buttonRechercheProprietaireCompte.on('click', function() {
+            GEOR.Addons.Cadastre.onClickRechercheProprietaire(2)
+        });
 
-            // sous-menu : recherche copropriété
-            var buttonRechercheCopropriete = scrollMenu.add({
-                tooltip : OpenLayers.i18n("cadastrapp.copropriete"),
-                text : OpenLayers.i18n("cadastrapp.copropriete")
-            });
-            buttonRechercheCopropriete.on('click', function() {
-                GEOR.Addons.Cadastre.onClickRechercheCoPropriete()
-            });
+        // sous-menu : recherche copropriété
+        var buttonRechercheCopropriete = scrollMenu.add({
+            tooltip : OpenLayers.i18n("cadastrapp.copropriete"),
+            text : OpenLayers.i18n("cadastrapp.copropriete")
+        });
+        buttonRechercheCopropriete.on('click', function() {
+            GEOR.Addons.Cadastre.onClickRechercheCoPropriete()
+        });
 
         // sous-menu : traitement sélection
         var scrollMenuTraitementSelection = new Ext.menu.Menu();
@@ -412,25 +411,25 @@ GEOR.Addons.Cadastre.Menu = Ext.extend(Ext.util.Observable, {
             GEOR.Addons.Cadastre.printSelectedBordereauParcellaire()
         });
 
-            // sous-sous-menu : traitement sélection - proprietaires
-            var scrollMenuTraitementSelectionProprietaires = new Ext.menu.Menu();
-            var buttonTraitementSelectionProprietaires = scrollMenuTraitementSelection.add({
-                id : 'owner-selection-submenu',
-                tooltip : OpenLayers.i18n("cadastrapp.selection.proprietaires"),
-                text : OpenLayers.i18n("cadastrapp.selection.proprietaires"),
-                menu : scrollMenuTraitementSelectionProprietaires
-            });
+        // sous-sous-menu : traitement sélection - proprietaires
+        var scrollMenuTraitementSelectionProprietaires = new Ext.menu.Menu();
+        var buttonTraitementSelectionProprietaires = scrollMenuTraitementSelection.add({
+            id : 'owner-selection-submenu',
+            tooltip : OpenLayers.i18n("cadastrapp.selection.proprietaires"),
+            text : OpenLayers.i18n("cadastrapp.selection.proprietaires"),
+            menu : scrollMenuTraitementSelectionProprietaires
+        });
 
-            // sous-sous-sous-menu : traitement sélection - proprietaire -
-            // export
-            var buttonTraitementSelectionProprietairesExport = scrollMenuTraitementSelectionProprietaires.add({
-                tooltip : OpenLayers.i18n("cadastrapp.selection.proprietaires.export"),
-                text : OpenLayers.i18n("cadastrapp.selection.proprietaires.export")
-            });
+        // sous-sous-sous-menu : traitement sélection - proprietaire -
+        // export
+        var buttonTraitementSelectionProprietairesExport = scrollMenuTraitementSelectionProprietaires.add({
+            tooltip : OpenLayers.i18n("cadastrapp.selection.proprietaires.export"),
+            text : OpenLayers.i18n("cadastrapp.selection.proprietaires.export")
+        });
 
-            buttonTraitementSelectionProprietairesExport.on('click', function() {
-                GEOR.Addons.Cadastre.exportOwnerSelectionAsCSV()
-            });
+        buttonTraitementSelectionProprietairesExport.on('click', function() {
+            GEOR.Addons.Cadastre.exportOwnerSelectionAsCSV()
+        });
 
     },
 
@@ -459,9 +458,9 @@ GEOR.Addons.Cadastre.Menu = Ext.extend(Ext.util.Observable, {
             tooltip : OpenLayers.i18n("cadastrapp.help"),
             iconCls : "help-button",
             iconAlign : 'top',
-            helpUrl: this.helpUrl,
+            helpUrl : this.helpUrl,
             text : OpenLayers.i18n("cadastrapp.help"),
-            handler: function() {
+            handler : function() {
                 if (Ext.isIE) {
                     window.open(this.helpUrl);
                 } else {
@@ -499,7 +498,7 @@ GEOR.Addons.Cadastre.Menu = Ext.extend(Ext.util.Observable, {
         // erase point
         event.feature.layer.removeAllFeatures();
     },
-    
+
     /**
      * 
      */

--- a/addons/cadastrapp/js/preferences.js
+++ b/addons/cadastrapp/js/preferences.js
@@ -14,6 +14,17 @@ GEOR.Addons.Cadastre.onClickLoadPreferencePanel= function(){
     GEOR.Addons.Cadastre.preferencesWindow.show();
 }
 
+/**
+ * Refresh Cadastrapp vector layers with current style
+ */
+GEOR.Addons.Cadastre.refreshLayerStyle = function(){
+    if(GEOR.Addons.Cadastre.WFSLayer){
+        // use localStorage to keep style preferences
+        GEOR.ls.set("cadastrapp_style_preference",JSON.stringify(GEOR.Addons.Cadastre.styles));
+        GEOR.Addons.Cadastre.WFSLayer.styleMap = GEOR.Addons.Cadastre.createLayerStyle(GEOR.Addons.Cadastre.styles);
+        GEOR.Addons.Cadastre.WFSLayer.redraw();
+    }
+}
 
 /**
  * initPreferencesWindow
@@ -24,77 +35,27 @@ GEOR.Addons.Cadastre.initPreferencesWindow = function() {
     
     // TabPanel to be include in main windows panel
     var preferenceTabPanel = new Ext.TabPanel({
+        activeTab: 0,
         items : [{
             title: OpenLayers.i18n('cadastrapp.preferences.default'),
             xtype : 'form',
-            items : [ {
-                xtype: 'compositefield',
+            items : [{
+                xtype: "colorpickerfield",
+                name: "cadaFillListColor",
+                id: "cadaFillListColor",
                 fieldLabel: OpenLayers.i18n('cadastrapp.preferences.fillColor'),
-                items: [{
-                    xtype: 'button',
-                    text: '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
-                    menu: {
-                        xtype: 'colormenu',
-                        value:  GEOR.Addons.Cadastre.styles.listed.fillColor.replace('#', ''),
-                        listeners: {
-                            select: function(menu, color) {
-                                color = "#" + color;
-                                menu.ownerCt.ownerCt.btnEl.setStyle("background", color);
-                                GEOR.Addons.Cadastre.styles.listed.fillColor = color;
-                            },
-                            scope: this
-                        }
+                value: GEOR.Addons.Cadastre.styles.listed.fillColor,
+                listeners: {
+                    focus: function(field){
+                        GEOR.Addons.Cadastre.styles.listed.fillColor = field.getValue();
+                        GEOR.Addons.Cadastre.refreshLayerStyle();
                     },
-                    listeners: {
-                    }
-                }]
-            }, {
-                xtype: 'compositefield',
-                fieldLabel: OpenLayers.i18n('cadastrapp.preferences.strokeColor'),
-                items: [{
-                    xtype: 'button',
-                    text: '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
-                    menu: {
-                        xtype: 'colormenu',
-                        value:  GEOR.Addons.Cadastre.styles.listed.strokeColor.replace('#', ''),
-                        listeners: {
-                            select: function(menu, color) {
-                                color = "#" + color;
-                                menu.ownerCt.ownerCt.btnEl.setStyle("background", color);
-                                GEOR.Addons.Cadastre.styles.listed.strokeColor = color;
-                            },
-                            scope: this
-                        }
-                    },
-                    listeners: {
-                    }
-                }]
-            },{
-                id: 'strokeSlider',
-                xtype: 'sliderfield',
-                name: 'strokeWidhtSlider',
-                fieldLabel: OpenLayers.i18n('cadastrapp.preferences.strokeWidth'),
-                value: GEOR.Addons.Cadastre.styles.listed.strokeWidth || 1,
-                width: 100,
-                minValue: 0,
-                maxValue: 36,
-                decimalPrecision: 0,
-                increment: 1,
-                tipText: function(thumb){
-                    var valOpacity = thumb.value;
-                    return String(valOpacity);
-                },
-                // Get default opacity value, give it to the feature style properties
-                // and draw feature if value change
-                listeners : {
-                    valid: function(slider) {
-                        GEOR.Addons.Cadastre.styles.listed.strokeWidth = slider.value;
-                    },
+                    scope: this
                 }
             },{
-                id: 'opacitySlider',
                 xtype: 'sliderfield',
-                name: 'Opacity',
+                name: 'cadaFillListOpacity',
+                id: 'cadaFillListOpacity',
                 fieldLabel: OpenLayers.i18n('cadastrapp.preferences.opacity'),
                 value: GEOR.Addons.Cadastre.styles.listed.opacity || 1,
                 width: 100,
@@ -106,21 +67,106 @@ GEOR.Addons.Cadastre.initPreferencesWindow = function() {
                     var valOpacity = thumb.value;
                     return String(Math.round(valOpacity*100)) + '%';
                 },
-                // Get default opacity value, give it to the feature style properties
-                // and draw feature if value change
                 listeners : {
                     valid: function(slider) {
                         GEOR.Addons.Cadastre.styles.listed.opacity = slider.value;
+                        GEOR.Addons.Cadastre.refreshLayerStyle();
                     },
                 }
+            },{
+                xtype: "colorpickerfield",
+                name: "cadaStroListColor",
+                id: "cadaStroListColor",
+                fieldLabel: OpenLayers.i18n('cadastrapp.preferences.strokeColor'),
+                value: GEOR.Addons.Cadastre.styles.listed.strokeColor,
+                listeners: {
+                    focus: function(field){
+                        GEOR.Addons.Cadastre.styles.listed.strokeColor = field.getValue();
+                        GEOR.Addons.Cadastre.refreshLayerStyle();
+                    },
+                    scope: this
+                }
+            },{
+                xtype: "textfield",
+                name: "cadaStroListWidth",
+                id: "cadaStroListWidth",
+                fieldLabel: OpenLayers.i18n('cadastrapp.preferences.strokeWidth'),
+                value: GEOR.Addons.Cadastre.styles.listed.strokeWidth,
+                listeners: {
+                    change: function(field, value) {
+                        GEOR.Addons.Cadastre.styles.listed.strokeWidth = value;
+                        GEOR.Addons.Cadastre.refreshLayerStyle();
+                    },
+                    scope: this
+                }
             }],
-            layout : 'fit',
             autoHeight: true
             
         },{
             title: OpenLayers.i18n('cadastrapp.preferences.selected'),
-            html: "Selected"
-            
+            xtype : 'form',
+            items : [ {
+                xtype: "colorpickerfield",
+                name: "cadaFillSelColor",
+                id: "cadaFillSelColor",
+                fieldLabel: OpenLayers.i18n('cadastrapp.preferences.fillColor'),
+                value: GEOR.Addons.Cadastre.styles.selected.fillColor,
+                listeners: {
+                    focus: function(field){
+                        GEOR.Addons.Cadastre.styles.selected.fillColor = field.getValue();
+                        GEOR.Addons.Cadastre.refreshLayerStyle();
+                    },
+                    scope: this
+                }
+            },{
+                xtype: 'sliderfield',
+                name: 'cadaFillSelOpacity',
+                id: 'cadaFillSelOpacity',
+                fieldLabel: OpenLayers.i18n('cadastrapp.preferences.opacity'),
+                value: GEOR.Addons.Cadastre.styles.selected.opacity || 1,
+                width: 100,
+                minValue: 0,
+                maxValue: 1,
+                decimalPrecision: 2,
+                increment: 0.01,
+                tipText: function(thumb){
+                    var valOpacity = thumb.value;
+                    return String(Math.round(valOpacity*100)) + '%';
+                },
+                listeners : {
+                    valid: function(slider) {
+                        GEOR.Addons.Cadastre.styles.selected.opacity = slider.value;
+                        GEOR.Addons.Cadastre.refreshLayerStyle();
+                    },
+                }
+            },{
+                xtype: "colorpickerfield",
+                name: "cadaStroSelColor",
+                id: "cadaStroSelColor",
+                fieldLabel: OpenLayers.i18n('cadastrapp.preferences.strokeColor'),
+                value: GEOR.Addons.Cadastre.styles.selected.strokeColor,
+                listeners: {
+                    focus: function(field){
+                        GEOR.Addons.Cadastre.styles.selected.strokeColor = field.getValue();
+                        GEOR.Addons.Cadastre.refreshLayerStyle();
+                    },
+                    scope: this
+                }
+            },{
+                xtype: "textfield",
+                name: "cadaStroSelWidth",
+                id: "cadaStroSelWidth",
+                fieldLabel: OpenLayers.i18n('cadastrapp.preferences.strokeWidth'),
+                value: GEOR.Addons.Cadastre.styles.selected.strokeWidth,
+                listeners: {
+                    change: function(field, value) {
+                        GEOR.Addons.Cadastre.styles.selected.strokeWidth = value;
+                        GEOR.Addons.Cadastre.refreshLayerStyle();
+                    },
+                    scope: this
+                }
+            }],
+            autoHeight: true            
         }],
     });
         
@@ -146,7 +192,32 @@ GEOR.Addons.Cadastre.initPreferencesWindow = function() {
                 GEOR.Addons.Cadastre.preferencesWindow = null;
             }
         },
-        items : preferenceTabPanel
+        items : preferenceTabPanel,
+        buttons : [ {
+            text : OpenLayers.i18n('cadastrapp.preferences.default.style'),
+            listeners : {
+                click : function(b, e) {
+                    GEOR.Addons.Cadastre.styles=GEOR.Addons.Cadastre.defaultStyles;
+                    GEOR.Addons.Cadastre.refreshLayerStyle();
+                    // reset default value to element
+                    Ext.getCmp("cadaFillListColor").setValue(GEOR.Addons.Cadastre.styles.listed.fillColor);
+                    Ext.getCmp("cadaFillSelColor").setValue(GEOR.Addons.Cadastre.styles.selected.fillColor);
+                    Ext.getCmp("cadaFillListOpacity").setValue(GEOR.Addons.Cadastre.styles.listed.opacity);
+                    Ext.getCmp("cadaFillSelOpacity").setValue(GEOR.Addons.Cadastre.styles.selected.opacity);
+                    Ext.getCmp("cadaStroListColor").setValue(GEOR.Addons.Cadastre.styles.listed.strokeColor);
+                    Ext.getCmp("cadaStroSelColor").setValue(GEOR.Addons.Cadastre.styles.selected.strokeColor);
+                    Ext.getCmp("cadaStroListWidth").setValue(GEOR.Addons.Cadastre.styles.listed.strokeWidth);
+                    Ext.getCmp("cadaStroSelWidth").setValue(GEOR.Addons.Cadastre.styles.selected.strokeWidth);
+                }
+            }
+        },{
+            text : OpenLayers.i18n('cadastrapp.close'),
+            listeners : {
+                click : function(b, e) {
+                    GEOR.Addons.Cadastre.preferencesWindow.close();
+                }
+            }
+        }]
     });
 
 }

--- a/addons/cadastrapp/js/preferences.js
+++ b/addons/cadastrapp/js/preferences.js
@@ -1,0 +1,152 @@
+Ext.namespace("GEOR.Addons.Cadastre");
+
+/**
+ * 
+ */
+GEOR.Addons.Cadastre.onClickLoadPreferencePanel= function(){
+    
+    // Close previous windows if already opened
+    if (GEOR.Addons.Cadastre.preferencesWindow != null) {
+        GEOR.Addons.Cadastre.preferencesWindow.close();
+    }
+
+    GEOR.Addons.Cadastre.initPreferencesWindow();
+    GEOR.Addons.Cadastre.preferencesWindow.show();
+}
+
+
+/**
+ * initPreferencesWindow
+ * 
+ * @returns Ext.Window 
+ */
+GEOR.Addons.Cadastre.initPreferencesWindow = function() {
+    
+    // TabPanel to be include in main windows panel
+    var preferenceTabPanel = new Ext.TabPanel({
+        items : [{
+            title: OpenLayers.i18n('cadastrapp.preferences.default'),
+            xtype : 'form',
+            items : [ {
+                xtype: 'compositefield',
+                fieldLabel: OpenLayers.i18n('cadastrapp.preferences.fillColor'),
+                items: [{
+                    xtype: 'button',
+                    text: '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
+                    menu: {
+                        xtype: 'colormenu',
+                        value:  GEOR.Addons.Cadastre.styles.listed.fillColor.replace('#', ''),
+                        listeners: {
+                            select: function(menu, color) {
+                                color = "#" + color;
+                                menu.ownerCt.ownerCt.btnEl.setStyle("background", color);
+                                GEOR.Addons.Cadastre.styles.listed.fillColor = color;
+                            },
+                            scope: this
+                        }
+                    },
+                    listeners: {
+                    }
+                }]
+            }, {
+                xtype: 'compositefield',
+                fieldLabel: OpenLayers.i18n('cadastrapp.preferences.strokeColor'),
+                items: [{
+                    xtype: 'button',
+                    text: '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
+                    menu: {
+                        xtype: 'colormenu',
+                        value:  GEOR.Addons.Cadastre.styles.listed.strokeColor.replace('#', ''),
+                        listeners: {
+                            select: function(menu, color) {
+                                color = "#" + color;
+                                menu.ownerCt.ownerCt.btnEl.setStyle("background", color);
+                                GEOR.Addons.Cadastre.styles.listed.strokeColor = color;
+                            },
+                            scope: this
+                        }
+                    },
+                    listeners: {
+                    }
+                }]
+            },{
+                id: 'strokeSlider',
+                xtype: 'sliderfield',
+                name: 'strokeWidhtSlider',
+                fieldLabel: OpenLayers.i18n('cadastrapp.preferences.strokeWidth'),
+                value: GEOR.Addons.Cadastre.styles.listed.strokeWidth || 1,
+                width: 100,
+                minValue: 0,
+                maxValue: 36,
+                decimalPrecision: 0,
+                increment: 1,
+                tipText: function(thumb){
+                    var valOpacity = thumb.value;
+                    return String(valOpacity);
+                },
+                // Get default opacity value, give it to the feature style properties
+                // and draw feature if value change
+                listeners : {
+                    valid: function(slider) {
+                        GEOR.Addons.Cadastre.styles.listed.strokeWidth = slider.value;
+                    },
+                }
+            },{
+                id: 'opacitySlider',
+                xtype: 'sliderfield',
+                name: 'Opacity',
+                fieldLabel: OpenLayers.i18n('cadastrapp.preferences.opacity'),
+                value: GEOR.Addons.Cadastre.styles.listed.opacity || 1,
+                width: 100,
+                minValue: 0,
+                maxValue: 1,
+                decimalPrecision: 2,
+                increment: 0.01,
+                tipText: function(thumb){
+                    var valOpacity = thumb.value;
+                    return String(Math.round(valOpacity*100)) + '%';
+                },
+                // Get default opacity value, give it to the feature style properties
+                // and draw feature if value change
+                listeners : {
+                    valid: function(slider) {
+                        GEOR.Addons.Cadastre.styles.listed.opacity = slider.value;
+                    },
+                }
+            }],
+            layout : 'fit',
+            autoHeight: true
+            
+        },{
+            title: OpenLayers.i18n('cadastrapp.preferences.selected'),
+            html: "Selected"
+            
+        }],
+    });
+        
+    // new windows
+    GEOR.Addons.Cadastre.preferencesWindow = new Ext.Window({
+        title : OpenLayers.i18n('cadastrapp.preferences.title'),
+        frame : true,
+        autoScroll : true,
+        minimizable : false,
+        closable : true,
+        resizable : false,
+        draggable : true,
+        constrainHeader : true,
+        border : false,
+        width : 300,
+        defaults : {
+            autoHeight : true,
+            bodyStyle : 'padding:10px',
+            flex : 1
+        },
+        listeners : {
+            close : function(window) {
+                GEOR.Addons.Cadastre.preferencesWindow = null;
+            }
+        },
+        items : preferenceTabPanel
+    });
+
+}

--- a/addons/cadastrapp/js/printBordereauParcellaire.js
+++ b/addons/cadastrapp/js/printBordereauParcellaire.js
@@ -23,7 +23,11 @@ GEOR.Addons.Cadastre.onClickPrintBordereauParcellaireWindow = function(parcelleI
         // PARAMS
         var params = {
             parcelle : parcelleId, 
-            personaldata:0
+            personaldata:0,
+            fillcolor:GEOR.Addons.Cadastre.styles.selected.fillColor,
+            opacity:GEOR.Addons.Cadastre.styles.selected.opacity,
+            strokecolor:GEOR.Addons.Cadastre.styles.selected.strokeColor,
+            strokewidth:GEOR.Addons.Cadastre.styles.selected.strokeWidth,
         } 
         var url = GEOR.Addons.Cadastre.cadastrappWebappUrl + 'createBordereauParcellaire?' + Ext.urlEncode(params);
 
@@ -117,6 +121,13 @@ GEOR.Addons.Cadastre.initPrintBordereauParcellaireWindow = function(parcelleId) 
 
                     // PARAMS
                     var params = GEOR.Addons.Cadastre.printBordereauParcellaireWindow.items.items[0].getForm().getValues();
+                    // Add style information
+                    // remove # to avoid URL problems on server side (XSL template doesnot manage url-encode)
+                    params.fillcolor=GEOR.Addons.Cadastre.styles.selected.fillColor.substring(1);;
+                    params.opacity=GEOR.Addons.Cadastre.styles.selected.opacity;
+                    params.strokecolor=GEOR.Addons.Cadastre.styles.selected.strokeColor.substring(1);;
+                    params.strokewidth=GEOR.Addons.Cadastre.styles.selected.strokeWidth;
+                    
                     var url = GEOR.Addons.Cadastre.cadastrappWebappUrl + 'createBordereauParcellaire?' + Ext.urlEncode(params);
 
                     // Needed for IE

--- a/addons/cadastrapp/js/selectFeature.js
+++ b/addons/cadastrapp/js/selectFeature.js
@@ -1,15 +1,15 @@
 Ext.namespace("GEOR.Addons.Cadastre");
 
+
 /**
- * Method: createSelectionControl
+ * Method: createLayerStyle
  * 
- * Create vector layer and associate style for plos
+ * Create style for vector layer using params
  * 
  * @param:styleParams
  * 
  */
-GEOR.Addons.Cadastre.createLayer = function(styleParams) {
-    
+GEOR.Addons.Cadastre.createLayerStyle = function(styleParams) {
     var defaultStyle = new OpenLayers.Style({
         fillColor : styleParams.listed.fillColor, 
         strokeColor : styleParams.listed.strokeColor,
@@ -17,7 +17,7 @@ GEOR.Addons.Cadastre.createLayer = function(styleParams) {
         fillOpacity : styleParams.listed.opacity,
         strokeOpacity : styleParams.listed.opacity,
     });
-
+    
     var selectStyle = new OpenLayers.Style({
         fillColor : styleParams.selected.fillColor, 
         strokeColor : styleParams.selected.strokeColor,
@@ -25,18 +25,32 @@ GEOR.Addons.Cadastre.createLayer = function(styleParams) {
         fillOpacity : styleParams.selected.opacity,
         strokeOpacity : styleParams.selected.opacity,
     });
-
+    
     var globalStyle = new OpenLayers.StyleMap({
         'default': defaultStyle,
         'select': selectStyle
     });
+    
+    return globalStyle;
+}
 
+/**
+ * Method: createLayer
+ * 
+ * Create vector layer and associate style for plots
+ * 
+ * @param:styleParams
+ * 
+ */
+GEOR.Addons.Cadastre.createLayer = function(styleParams) {
+    
+   
     // création de la couche des entités selectionnées
     GEOR.Addons.Cadastre.WFSLayer = new OpenLayers.Layer.Vector("__georchestra_cadastrapps_plots", {
         displayInLayerSwitcher : false,
-        styleMap:globalStyle
+        styleMap:GEOR.Addons.Cadastre.createLayerStyle(styleParams)
     });
-
+    
     GEOR.Addons.Cadastre.WFSLayer.selectControl = new OpenLayers.Control.SelectFeature([GEOR.Addons.Cadastre.WFSLayer]);
 
     GeoExt.MapPanel.guess().map.addControl(GEOR.Addons.Cadastre.WFSLayer.selectControl);

--- a/addons/cadastrapp/manifest.json
+++ b/addons/cadastrapp/manifest.json
@@ -2,7 +2,8 @@
 	"js": [
 		"js/build/cadastrapp.js"
 	],
-	"debugjs":[		
+	"debugjs":[	
+		"js/preferences.js",	
         "js/printBordereauParcellaire.js",
         "js/printRelevePropriete.js",
         "js/printLots.js",
@@ -45,13 +46,13 @@
             "version":"1.0.0",
             "service":"wfs",
             "outputFormat":"application/json",
-            "geometryField":"geom"
+            "geometryField":"shape"
         },
         "style":{
         	"listed":{  
-            	"fillColor":"#FFFF00",
+            	"fillColor":"#222111",
             	"opacity":"0.4",
-            	"strokeColor":"#FFFF00",
+            	"strokeColor":"#111222",
             	"strokeWidth":"2"
             },
             "selected":{
@@ -70,7 +71,7 @@
             "version":"1.0.0",
             "service":"wfs",
             "outputFormat":"application/json",
-            "geometryField":"geom"
+            "geometryField":"shape"
         },
         "foncier":true
     },
@@ -241,6 +242,7 @@
             "cadastrapp.menu.parcelle.identifiant":"By cadastral identifier",
             "cadastrapp.menu.parcelle.lot":"Par lot",
             "cadastrapp.menu.parcelle.refer":"By reference",
+            "cadastrapp.menu.preference":"Preference",
             "cadastrapp.menu.tooltips.foncier":"Landed property information",
             "cadastrapp.multilinestring":"MultiLineString",
             "cadastrapp.multipoint":"MultiPoint",
@@ -319,6 +321,13 @@
             "cadastrapp.parcelle.town.exemple":"ex. Henri Freville or La morinaie",
             "cadastrapp.point":"Point",
             "cadastrapp.polygon":"Polygon",
+            "cadastrapp.preferences.default":"Default",
+            "cadastrapp.preferences.fillColor" :"Fill color",
+            "cadastrapp.preferences.opacity" :"Opacity",
+            "cadastrapp.preferences.selected":"Selected",
+            "cadastrapp.preferences.strokeColor" :"Stroke",
+            "cadastrapp.preferences.strokeWidth" :"Stroke width", 
+            "cadastrapp.preferences.title":"Preferences",
             "cadastrapp.proprietaire":"Owner",
             "cadastrapp.proprietaire.city":"Town, municipality",
             "cadastrapp.proprietaire.city.exemple":"ex. Rennes, Cesson-Sévigné",
@@ -363,7 +372,7 @@
             "cadastrapp.proprietaires.dqualp":"Mr, Mrs, or Ms",
             "cadastrapp.proprietaires.expnee":"complement",
             "cadastrapp.proprietaires.jdatnss":"Birthdate",
-            "cadastrapp.recherches":"Advanced searches",
+            "cadastrapp.recherches":"Advanced",
             "cadastrapp.relevepropriete.data":"Data to extract",
             "cadastrapp.relevepropriete.full":"All properties",
             "cadastrapp.relevepropriete.partial":"Only this plot",
@@ -597,6 +606,7 @@
             "cadastrapp.menu.parcelle.identifiant":"Par identifiant cadastral",
             "cadastrapp.menu.parcelle.lot":"Par lot",
             "cadastrapp.menu.parcelle.refer":"Par référence",
+            "cadastrapp.menu.preference":"Préférences",
             "cadastrapp.menu.tooltips.foncier":"Outil d'information foncière, une fois activée cliquez sur une parcelle pour voir l'unité foncière correspondante",
             "cadastrapp.multilinestring":"MultidCompteComiLigne",
             "cadastrapp.multipoint":"MultiPoint",
@@ -673,6 +683,13 @@
             "cadastrapp.parcelle.town.exemple":"ex. Henri Fréville ou Mont-Romain",
             "cadastrapp.point":"Point",
             "cadastrapp.polygon":"Polygone",
+            "cadastrapp.preferences.default":"Défaut",
+            "cadastrapp.preferences.fillColor" :"Remplissage",
+            "cadastrapp.preferences.opacity" :"Opacity",
+            "cadastrapp.preferences.selected":"Sélectionné",
+            "cadastrapp.preferences.strokeColor" :"Contour",
+            "cadastrapp.preferences.strokeWidth" :"Epaisseur", 
+            "cadastrapp.preferences.title":"Préférences",
             "cadastrapp.proprietaire":"Propriétaire",
             "cadastrapp.proprietaire.city":"Ville, Commune",
             "cadastrapp.proprietaire.city.exemple":"ex. Rennes, Cesson-Sévigné",
@@ -717,7 +734,7 @@
             "cadastrapp.proprietaires.dqualp":"Qualité abrégée - M, MME ou MLE",
             "cadastrapp.proprietaires.expnee":"Mention du complément",
             "cadastrapp.proprietaires.jdatnss":"Date de naissance",
-            "cadastrapp.recherches":"Recherches avancées",
+            "cadastrapp.recherches":"Avancées..",
             "cadastrapp.relevepropriete.data":"Données à extraire",
             "cadastrapp.relevepropriete.full":"Toutes les propriétés",
             "cadastrapp.relevepropriete.partial":"Uniquement cette parcelle",

--- a/addons/cadastrapp/manifest.json
+++ b/addons/cadastrapp/manifest.json
@@ -46,7 +46,7 @@
             "version":"1.0.0",
             "service":"wfs",
             "outputFormat":"application/json",
-            "geometryField":"shape"
+            "geometryField":"geom"
         },
         "style":{
         	"listed":{  
@@ -71,7 +71,7 @@
             "version":"1.0.0",
             "service":"wfs",
             "outputFormat":"application/json",
-            "geometryField":"shape"
+            "geometryField":"geom"
         },
         "foncier":true
     },
@@ -322,6 +322,7 @@
             "cadastrapp.point":"Point",
             "cadastrapp.polygon":"Polygon",
             "cadastrapp.preferences.default":"Default",
+            "cadastrapp.preferences.default.style":"Set default style",
             "cadastrapp.preferences.fillColor" :"Fill color",
             "cadastrapp.preferences.opacity" :"Opacity",
             "cadastrapp.preferences.selected":"Selected",
@@ -683,13 +684,14 @@
             "cadastrapp.parcelle.town.exemple":"ex. Henri Fréville ou Mont-Romain",
             "cadastrapp.point":"Point",
             "cadastrapp.polygon":"Polygone",
-            "cadastrapp.preferences.default":"Défaut",
+            "cadastrapp.preferences.default":"Liste",
+            "cadastrapp.preferences.default.style":"Reprendre le style par defaut",
             "cadastrapp.preferences.fillColor" :"Remplissage",
-            "cadastrapp.preferences.opacity" :"Opacity",
-            "cadastrapp.preferences.selected":"Sélectionné",
+            "cadastrapp.preferences.opacity" :"Opacité",
+            "cadastrapp.preferences.selected":"Sélection",
             "cadastrapp.preferences.strokeColor" :"Contour",
             "cadastrapp.preferences.strokeWidth" :"Epaisseur", 
-            "cadastrapp.preferences.title":"Préférences",
+            "cadastrapp.preferences.title":"Préférences des styles",
             "cadastrapp.proprietaire":"Propriétaire",
             "cadastrapp.proprietaire.city":"Ville, Commune",
             "cadastrapp.proprietaire.city.exemple":"ex. Rennes, Cesson-Sévigné",

--- a/cadastrapp/jsbuild/main.cfg
+++ b/cadastrapp/jsbuild/main.cfg
@@ -2,6 +2,7 @@
 root = ../../addons/cadastrapp/js
 
 include =
+	preferences.js
  	printBordereauParcellaire.js
 	printRelevePropriete.js	
 	printLots.js	

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/model/pdf/BordereauParcellaire.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/model/pdf/BordereauParcellaire.java
@@ -21,6 +21,8 @@ public class BordereauParcellaire {
 	
 	private String serviceUrl;
 	
+	private Style style; 
+	
 	private List<Parcelle> parcelleList;
 	
 	private List<String> fieldSearch;
@@ -157,6 +159,21 @@ public class BordereauParcellaire {
 	 */
 	public void setEmpty(boolean isEmpty) {
 		this.isEmpty = isEmpty;
+	}
+
+	/**
+	 * @return the style
+	 */
+	public Style getStyle() {
+		return style;
+	}
+
+	@XmlElement
+	/**
+	 * @param style the style to set
+	 */
+	public void setStyle(Style style) {
+		this.style = style;
 	}
 	
 }

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/model/pdf/Style.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/model/pdf/Style.java
@@ -1,0 +1,62 @@
+package org.georchestra.cadastrapp.model.pdf;
+
+
+import javax.xml.bind.annotation.XmlAttribute;
+
+
+public class Style {
+	
+	public Style() {
+	}
+	
+	// couleur de remplissage de la parcelle
+	private String fillColor;
+	
+	// opacité de remplissage de la parcelle
+	private float fillOpacity;
+	
+	// couleur du contour de la parcelle
+	private String strokeColor;
+	
+	// épaisseur du contour de la parcelle
+	private int strokeWidth;
+
+	public String getFillColor() {
+		return fillColor;
+	}
+
+	@XmlAttribute
+	public void setFillColor(String fillColor) {
+		this.fillColor = fillColor;
+	}
+
+	public float getFillOpacity() {
+		return fillOpacity;
+	}
+
+	@XmlAttribute
+	public void setFillOpacity(float fillOpacity) {
+		this.fillOpacity = fillOpacity;
+	}
+
+	public String getStrokeColor() {
+		return strokeColor;
+	}
+
+	@XmlAttribute
+	public void setStrokeColor(String strokeColor) {
+		this.strokeColor = strokeColor;
+	}
+
+	public int getStrokeWidth() {
+		return strokeWidth;
+	}
+
+	@XmlAttribute
+	public void setStrokeWidth(int strokeWidth) {
+		this.strokeWidth = strokeWidth;
+	}
+	
+	
+
+}

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/pdf/BordereauParcellaireController.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/pdf/BordereauParcellaireController.java
@@ -41,6 +41,7 @@ import org.apache.fop.apps.FopFactoryBuilder;
 import org.apache.fop.apps.MimeConstants;
 import org.georchestra.cadastrapp.configuration.CadastrappPlaceHolder;
 import org.georchestra.cadastrapp.model.pdf.BordereauParcellaire;
+import org.georchestra.cadastrapp.model.pdf.Style;
 import org.georchestra.cadastrapp.service.CadController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,7 +72,13 @@ public class BordereauParcellaireController extends CadController {
 	@GET
 	@Path("/createBordereauParcellaire")
 	@Produces("application/pdf")
-	public Response createBordereauParcellaire(@Context HttpHeaders headers, @QueryParam("parcelle") final List<String> parcelleList, @DefaultValue("0") @QueryParam("personaldata") int personalData) {
+	public Response createBordereauParcellaire(@Context HttpHeaders headers, 
+			@QueryParam("parcelle") final List<String> parcelleList,
+			@DefaultValue("0") @QueryParam("personaldata") int personalData,
+			@DefaultValue("#1446DE") @QueryParam("fillcolor") String styleFillColor,
+			@DefaultValue("0.50") @QueryParam("opacity") float styleFillOpacity,
+			@DefaultValue("#10259E") @QueryParam("strokecolor") String styleStrokeColor,
+			@DefaultValue("2") @QueryParam("strokewidth") int styleStrokeWidth) {
 
 		ResponseBuilder response = Response.noContent();
 		
@@ -127,9 +134,16 @@ public class BordereauParcellaireController extends CadController {
 				jaxbMarshaller = jaxbContext.createMarshaller();
 
 				jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+				
+				// Create plot style 
+				Style plotsStyle = new Style();
+				plotsStyle.setFillColor(styleFillColor);
+				plotsStyle.setFillOpacity(styleFillOpacity);
+				plotsStyle.setStrokeColor(styleStrokeColor);
+				plotsStyle.setStrokeWidth(styleStrokeWidth);
 
 				// Get bordereau parcellaire information
-				BordereauParcellaire bordereauParcellaire = bordereauParcellaireHelper.getBordereauParcellaireInformation(newParcelleList, personalData, headers, false);
+				BordereauParcellaire bordereauParcellaire = bordereauParcellaireHelper.getBordereauParcellaireInformation(newParcelleList, personalData, headers, false, plotsStyle);
 				File xmlfile = null;
 				File foFile = null;
 				OutputStream foOutPutStream = null;

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/pdf/BordereauParcellaireHelper.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/pdf/BordereauParcellaireHelper.java
@@ -36,6 +36,7 @@ import org.georchestra.cadastrapp.configuration.CadastrappPlaceHolder;
 import org.georchestra.cadastrapp.model.pdf.BordereauParcellaire;
 import org.georchestra.cadastrapp.model.pdf.Parcelle;
 import org.georchestra.cadastrapp.model.pdf.Proprietaire;
+import org.georchestra.cadastrapp.model.pdf.Style;
 import org.georchestra.cadastrapp.service.CadController;
 import org.georchestra.cadastrapp.service.exception.CadastrappServiceException;
 import org.slf4j.Logger;
@@ -69,7 +70,7 @@ public final class BordereauParcellaireHelper extends CadController{
 	 * 
 	 * @return BordereauParcellaire witch contains list of parcelle
 	 */
-	public BordereauParcellaire getBordereauParcellaireInformation(List<String> parcelleList, int personalData, HttpHeaders headers, boolean isCoPro) {
+	public BordereauParcellaire getBordereauParcellaireInformation(List<String> parcelleList, int personalData, HttpHeaders headers, boolean isCoPro, Style plotStyle) {
 
 		
 		BordereauParcellaire bordereauParcellaire = new BordereauParcellaire();
@@ -86,7 +87,8 @@ public final class BordereauParcellaireHelper extends CadController{
 			bordereauParcellaire.setDateDeValiditeMajic(dateValiditeDonneesMajic);
 			bordereauParcellaire.setDateDeValiditeEdigeo(dateValiditeDonneesEDIGEO);
 			bordereauParcellaire.setService(organisme);
-			bordereauParcellaire.setServiceUrl(webappUrl);
+			bordereauParcellaire.setServiceUrl(webappUrl);		
+			bordereauParcellaire.setStyle(plotStyle);
 
 			List<Parcelle> parcellesInformation = new ArrayList<Parcelle>();
 

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/pdf/DemandeController.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/pdf/DemandeController.java
@@ -260,7 +260,7 @@ public class DemandeController extends CadController {
 		parcellId.add(parcelle);
 
 		// Get bordereau parcellaire information
-		BordereauParcellaire bordereauParcellaire = bordereauParcellaireHelper.getBordereauParcellaireInformation(parcellId, 1, headers,false);
+		BordereauParcellaire bordereauParcellaire = bordereauParcellaireHelper.getBordereauParcellaireInformation(parcellId, 1, headers,false, null);
 
 		File pdf = null;
 		try {
@@ -326,7 +326,7 @@ public class DemandeController extends CadController {
 		}
 
 		// Get bordereau parcellaire information
-		BordereauParcellaire bordereauParcellaire = bordereauParcellaireHelper.getBordereauParcellaireInformation(parcellesId, 1, headers, isCoPro);
+		BordereauParcellaire bordereauParcellaire = bordereauParcellaireHelper.getBordereauParcellaireInformation(parcellesId, 1, headers, isCoPro, null);
 		try {
 			//generate PDF
 			if(bordereauParcellaire.isEmpty()){
@@ -408,7 +408,7 @@ public class DemandeController extends CadController {
 
 		}
 		// Get bordereau parcellaire information
-		BordereauParcellaire bordereauParcellaire = bordereauParcellaireHelper.getBordereauParcellaireInformation(parcellId, 1, headers,false);
+		BordereauParcellaire bordereauParcellaire = bordereauParcellaireHelper.getBordereauParcellaireInformation(parcellId, 1, headers,false, null);
 		File pdf = null;
 		try {
 			//generate PDF
@@ -481,7 +481,7 @@ public class DemandeController extends CadController {
 
 		}
 		// Get bordereau parcellaire information
-		BordereauParcellaire bordereauParcellaire = bordereauParcellaireHelper.getBordereauParcellaireInformation(parcellId, 1, headers,false);
+		BordereauParcellaire bordereauParcellaire = bordereauParcellaireHelper.getBordereauParcellaireInformation(parcellId, 1, headers,false, null);
 		File pdf = null;
 		try {
 			//generate PDF
@@ -553,7 +553,7 @@ public class DemandeController extends CadController {
 
 		}
 		// Get bordereau parcellaire information
-		BordereauParcellaire bordereauParcellaire = bordereauParcellaireHelper.getBordereauParcellaireInformation(parcellId, 1, headers,false);
+		BordereauParcellaire bordereauParcellaire = bordereauParcellaireHelper.getBordereauParcellaireInformation(parcellId, 1, headers,false, null);
 
 		File pdf = null;
 		try {

--- a/cadastrapp/src/main/resources/xsl/bordereauParcellaire.xsl
+++ b/cadastrapp/src/main/resources/xsl/bordereauParcellaire.xsl
@@ -70,7 +70,19 @@
 		<xsl:variable name="dateDeValiditeEdigeo">
 			<xsl:value-of select="dateDeValiditeEdigeo" />
 		</xsl:variable>
-
+		<xsl:variable name="fillColor">
+			<xsl:value-of select="style/@fillColor" />
+		</xsl:variable>
+		<xsl:variable name="fillOpacity">
+			<xsl:value-of select="style/@fillOpacity" />
+		</xsl:variable>
+		<xsl:variable name="strokeColor">
+			<xsl:value-of select="style/@strokeColor" />
+		</xsl:variable>
+		<xsl:variable name="strokeWidth">
+			<xsl:value-of select="style/@strokeWidth" />
+		</xsl:variable>
+		
 		<xsl:for-each select="parcelles/parcelle">
 			<fo:table table-layout="fixed" page-break-before="always">
 				<fo:table-column column-width="72%" />
@@ -82,7 +94,16 @@
 							<fo:block>
 								<fo:external-graphic  content-width="scale-to-fit" content-height="100%" width="100%" scaling="uniform">
 									<xsl:attribute name="src">
-										<xsl:value-of select="$serviceUrl" />/getImageBordereau?parcelle=<xsl:value-of select="@parcelleId" />
+										<xsl:choose>
+											<!--  with given style -->
+											<xsl:when test="$fillColor">								
+												<xsl:value-of select="$serviceUrl" />/getImageBordereau?parcelle=<xsl:value-of select="@parcelleId" /><![CDATA[&]]>fillcolor=<xsl:value-of select="$fillColor" /><![CDATA[&]]>fillopacity=<xsl:value-of select="$fillOpacity" /><![CDATA[&]]>strokecolor=<xsl:value-of select="$strokeColor" /><![CDATA[&]]>strokewidth=<xsl:value-of select="$strokeWidth" />
+											</xsl:when>
+											<!--  without style -->
+											<xsl:otherwise>			
+												<xsl:value-of select="$serviceUrl" />/getImageBordereau?parcelle=<xsl:value-of select="@parcelleId" />
+											</xsl:otherwise>	
+										</xsl:choose>
 									</xsl:attribute>
 								</fo:external-graphic>
 							</fo:block>

--- a/cadastrapp/src/test/java/org/georchestra/cadastrapp/service/ImageParcelleControllerTest.java
+++ b/cadastrapp/src/test/java/org/georchestra/cadastrapp/service/ImageParcelleControllerTest.java
@@ -33,7 +33,7 @@ public class ImageParcelleControllerTest {
 
 		ImageParcelleController imageParcelleController = new ImageParcelleController();
 		
-		Response response = imageParcelleController.createImageBordereauParcellaire("2014630103000AO0351");
+		Response response = imageParcelleController.createImageBordereauParcellaire("2014630103000AO0351", "#1446DE", (float) 0.50, "#10259E",2);
 
 
 	}


### PR DESCRIPTION
Modification du style de sélection par un utilisateur

Cette PR permet à l'utilisateur via un menu dans la barre de navigation et le bouton avancée puis préférence de choisir le style des parcelles. Deux styles différents sont configurable
1 - liste qui correspond aux parcelles qui sont listées dans la fenêtre de résultat de parcelle
2 - sélectionné qui correspond aux parcelles sélectionnées dans la liste.

La préférence utilisateur est stocké dans le localstorage en utilisation de GEOR.ls.set et GEOR.ls.get.

Cette préférence est envoyée au serveur lors de la création d'un bordereau parcellaire.
Par contre elle n'est pas envoyé dans de demande d'information.

Le style sélectionné est aussi utilisé pour l'impression de UF. 

Dans les nombreux tests que j'ai pu faire, il me semble que les deux styles se superposent l'un sur l'autre dans mapfishapp. Et a priori c'est déjà le cas avec cette PR.
Ce n'est pas le cas dans le BP, le rendu est donc légèrement différent (c'est d'ailleurs comme ça que je m'en suis rendu compte)