### PR TITLE
version debian package

### DIFF
--- a/cadastrapp/pom.xml
+++ b/cadastrapp/pom.xml
@@ -623,8 +623,8 @@
                   <target>
                     <condition property="project.packageVersion"
                       value="99.master.${maven.build.timestamp}~${build.commit.id.abbrev}"
-                      else="${project.version}.${maven.build.timestamp}~${build.commit.id.abbrev}">
-                      <matches string="${project.version}" pattern="SNAPSHOT$" />
+                      else="${project.parent.version}.${maven.build.timestamp}~${build.commit.id.abbrev}">
+                      <matches string="${project.parent.version}" pattern="SNAPSHOT$" />
                     </condition>
                   </target>
                 </configuration>

--- a/cadastrapp/pom.xml
+++ b/cadastrapp/pom.xml
@@ -657,6 +657,7 @@
             <configuration>
               <packageName>georchestra-${project.artifactId}</packageName>
               <packageDescription>Cadastrapp webapp for geOrchestra</packageDescription>
+              <packageVersion>${project.packageVersion}</packageVersion>
               <packageDependencies>
                 <packageDependency>debconf</packageDependency>
               </packageDependencies>
@@ -665,7 +666,6 @@
               <maintainerName>Pierre Jego</maintainerName>
               <maintainerEmail>pierre.jego@jdev.fr</maintainerEmail>
               <excludeAllArtifacts>true</excludeAllArtifacts>
-              <snapshotRevisionFile>${project.build.directory}</snapshotRevisionFile>
             </configuration>
           </plugin>
         </plugins>

--- a/cadastrapp/pom.xml
+++ b/cadastrapp/pom.xml
@@ -610,8 +610,25 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
-            <version>1.6</version>
+            <version>1.7</version>
             <executions>
+              <execution>
+                <id>set-project-packageversion</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <exportAntProperties>true</exportAntProperties>
+                  <target>
+                    <condition property="project.packageVersion"
+                      value="99.master.${maven.build.timestamp}~${build.commit.id.abbrev}"
+                      else="${project.version}.${maven.build.timestamp}~${build.commit.id.abbrev}">
+                      <matches string="${project.version}" pattern="SNAPSHOT$" />
+                    </condition>
+                  </target>
+                </configuration>
+              </execution>
               <execution>
                 <id>fix-permissions</id>
                 <phase>package</phase>

--- a/cadastrapp/pom.xml
+++ b/cadastrapp/pom.xml
@@ -525,6 +525,23 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>pl.project13.maven</groupId>
+        <artifactId>git-commit-id-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <prefix>build</prefix>
+          <failOnNoGitDirectory>false</failOnNoGitDirectory>
+          <skipPoms>false</skipPoms>
+          <verbose>false</verbose>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
   </scm>
   <properties>
     <project.scm.id>cadastrapp-release</project.scm.id>
+    <maven.build.timestamp.format>yyyyMMddHHmm</maven.build.timestamp.format>
   </properties>
   <issueManagement>
     <system>GitHub Issues</system>


### PR DESCRIPTION
same thing as georchestra/georchestra#1931, produces `georchestra-cadastrapp_99.master.201903261446~3b4bace-1_all.deb` on master and `georchestra-cadastrapp_1.7.201903261450~ab4563a-1_all.deb` when built on top of c7e949b (with some commits stashed)