### PR TITLE
docker - jetty-env.xml no longer in the official datadir

### DIFF
--- a/cadastrapp/pom.xml
+++ b/cadastrapp/pom.xml
@@ -489,7 +489,7 @@
         <artifactId>cxf-java2wadl-plugin</artifactId>
         <version>${cxf.version}</version>
         <executions>
-          <!-- Enable if support for Javadoc is required, not supported in CXF 
+          <!-- Enable if support for Javadoc is required, not supported in CXF
 						2.7.11 -->
           <execution>
             <id>parsejavadoc</id>
@@ -728,40 +728,11 @@
       <id>docker</id>
       <properties>
         <dockerImageName>georchestra/${project.artifactId}</dockerImageName>
-        <dockerDatadirScmUrl>scm:git:https://github.com/georchestra/datadir.git</dockerDatadirScmUrl>
         <dockerDatadirScmVersion>docker-master</dockerDatadirScmVersion>
       </properties>
       <build>
         <finalName>${project.artifactId}</finalName>
         <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-scm-plugin</artifactId>
-            <version>1.9.4</version>
-            <configuration>
-              <checkoutDirectory>${project.build.directory}/datadir/</checkoutDirectory>
-              <connectionUrl>${dockerDatadirScmUrl}</connectionUrl>
-              <pushChanges>false</pushChanges>
-              <scmVersion>${dockerDatadirScmVersion}</scmVersion>
-              <scmVersionType>branch</scmVersionType>
-            </configuration>
-            <executions>
-              <execution>
-                <id>checkout-docker-default-datadir</id>
-                <phase>process-resources</phase>
-                <goals>
-                  <goal>checkout</goal>
-                </goals>
-              </execution>
-            </executions>
-            <dependencies>
-              <dependency>
-                <groupId>org.apache.maven.scm</groupId>
-                <artifactId>maven-scm-provider-gitexe</artifactId>
-                <version>1.9.4</version>
-              </dependency>
-            </dependencies>
-          </plugin>
           <plugin>
             <groupId>com.spotify</groupId>
             <artifactId>docker-maven-plugin</artifactId>
@@ -775,13 +746,8 @@
                   <directory>${project.build.directory}</directory>
                   <include>${project.artifactId}.war</include>
                 </resource>
-                <resource>
-                  <targetPath>/etc/georchestra</targetPath>
-                  <directory>${project.build.directory}/datadir</directory>
-                  <include>${project.artifactId}/**</include>
-                </resource>
               </resources>
-              <!-- This will require to set up the docker-hub credentials correctly 
+              <!-- This will require to set up the docker-hub credentials correctly
 								into your ~/.m2/settings.xml, see: https://github.com/spotify/docker-maven-plugin#authenticating-with-private-registries -->
               <serverId>docker-hub</serverId>
               <registryUrl>https://index.docker.io/v1/</registryUrl>

--- a/cadastrapp/src/docker/Dockerfile
+++ b/cadastrapp/src/docker/Dockerfile
@@ -7,8 +7,7 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,jmx-remote,stats
 USER root
 
 RUN  unzip -d /var/lib/jetty/webapps/cadastrapp /var/lib/jetty/webapps/cadastrapp.war && \
-  rm -f /var/lib/jetty/webapps/cadastrapp.war &&                                         \
-  cp /etc/georchestra/cadastrapp/jetty-env.xml /var/lib/jetty/webapps/cadastrapp/WEB-INF/
+  rm -f /var/lib/jetty/webapps/cadastrapp.war
 
 USER jetty
 
@@ -16,4 +15,3 @@ CMD ["sh", "-c", "exec java -Djava.io.tmpdir=/tmp/jetty -Dgeorchestra.datadir=/e
  -Xmx${XMX:-512m} -Xms${XMX:-512m}                                                             \
  $TRUSTORE_PASSWORD $TRUSTSTORE_PATH                                                           \
  -jar /usr/local/jetty/start.jar"]
-


### PR DESCRIPTION
The jetty-env.xml file expected by the Dockerfile no longer exists, which makes a docker maven build fail. This also spares a git clone of the datadir, making the build faster in that case.
