### PR TITLE
Improve resilency of the jsbuild script.

### DIFF
--- a/.github/workflows/cadastrapp.yml
+++ b/.github/workflows/cadastrapp.yml
@@ -23,11 +23,6 @@ jobs:
       with:
         python-version: '2.x'
 
-    - name: "installing jsbuild and virtualenv via pip"
-      run: |
-        pip install jsbuild
-        pip install virtualenv
-
     - name: "Maven repository caching"
       uses: actions/cache@v1
       with:
@@ -67,11 +62,6 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: '2.x'
-
-    - name: "installing jsbuild and virtualenv via pip"
-      run: |
-        pip install jsbuild
-        pip install virtualenv
 
     - name: "Maven repository caching"
       uses: actions/cache@v1

--- a/README.md
+++ b/README.md
@@ -24,14 +24,7 @@ This repository is made of 3 mains parts :
 - addons folder contains client side of application
 - cadastrapp folder contains webapplication distributing webservice
 
-Additional tool is needed to build from source ( jsbuild from pythonvirtualenv)
-
-```
-	sudo apt-get install python-pip
-	sudo pip install jsbuild
-	sudo pip install virtualenv
-	sudo /usr/bin/easy_install virtualenv
-```
+Additional tool is needed to build from source (python2)
 
 
 ## Sponsors

--- a/cadastrapp/jsbuild/jsbuild.sh
+++ b/cadastrapp/jsbuild/jsbuild.sh
@@ -8,7 +8,8 @@ venv="${buildpath}/env"
 #
 # Command path definitions
 #
-python="/usr/bin/python"
+python="/usr/bin/env python2"
+virtualenv="/usr/bin/env virtualenv --python=${python}"
 mkdir="/bin/mkdir"
 rm="/bin/rm"
 sh="/bin/sh"
@@ -26,12 +27,22 @@ fi
 ${mkdir} -p ${releasepath}
 
 (cd ${buildpath};
- ${venv}/bin/jsbuild -h > /dev/null
+ ${python} -c "import pip"
+ if [ $? != 0 ]; then
+    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+    ${python} get-pip.py
+    rm get-pip.py
+ fi
+ ${python} -c "import virtualenv"
+ if [ $? != 0 ]; then
+   ${python} -m pip install virtualenv
+ fi
+
  if  [ ! -d ${venv} ] || [ $? -eq 0 ]; then
      echo "creating virtual env and installing jstools..."
      rm -rf ${venv}
-     virtualenv ${venv}
-     ${venv}/bin/pip install jstools==0.6
+     ${python} -m virtualenv ${venv}
+     ${venv}/bin/python -m pip install jstools==0.6
      echo "done."
  fi;
 


### PR DESCRIPTION
It now force the use of python2 and ensure virtualenv is using python2.
This script could potentialy fail since new version of distribution like
debian, red hat, etc... now use python3 as the default version in the
system. Also remove the dep install in CI since the script takes care of
it. This script is based on the one used in mapfishapp in georchestra.

Fix #515 