### PR TITLE
Correction du filtrage spatial pour les orgs ayant un filtrage sur commune et departement

### DIFF
--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/CadController.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/CadController.java
@@ -201,9 +201,9 @@ public class CadController {
 				}
 				
 	
+				queryFilter.append(" AND ( ");
 				// If table contains cgocommune
 				if(!deps.isEmpty()){
-					queryFilter.append(" AND ( ");
 					boolean isFirstDep = true;
 					for (String dep : deps){
 						if(!isFirstDep){
@@ -216,19 +216,20 @@ public class CadController {
 							isFirstDep = false;
 						}
 					}		
-					queryFilter.append(" ) ");
 				}
 				if(!communes.isEmpty()){
 					if(!deps.isEmpty()) {
 						queryFilter.append(" OR ");
-					} else {
-						queryFilter.append(" AND ");
 					}
 					queryFilter.append(tableAlias);
 					queryFilter.append("cgocommune IN (");
 					queryFilter.append(createListToStringQuery(communes));					
 					queryFilter.append(" ) ");
 				}			
+				queryFilter.append(" ) ");
+				if(logger.isDebugEnabled()){
+					logger.debug("Resulting geographical SQL filter : " + queryFilter.toString());
+				}
 			}			
 		}
 		else{

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/CadController.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/CadController.java
@@ -219,7 +219,11 @@ public class CadController {
 					queryFilter.append(" ) ");
 				}
 				if(!communes.isEmpty()){
-					queryFilter.append(" AND ");
+					if(!deps.isEmpty()) {
+						queryFilter.append(" OR ");
+					} else {
+						queryFilter.append(" AND ");
+					}
 					queryFilter.append(tableAlias);
 					queryFilter.append("cgocommune IN (");
 					queryFilter.append(createListToStringQuery(communes));					


### PR DESCRIPTION
Corrige #374 
testé dans 3 cas:
- avec un org ayant une emprise sur une commune:
```
Resulting geographical SQL filter :  AND ( prop.cgocommune IN ('380063' )  )
```
- avec un org ayant une emprise sur plusieurs dept:
```
Resulting geographical SQL filter :  AND ( prop.cgocommune LIKE '01%'  OR prop.cgocommune LIKE '03%'  OR prop.cgocommune LIKE '07%'  OR prop.cgocommune LIKE '15%'  OR prop.cgocommune LIKE '26%'  OR prop.cgocommune LIKE '38%'  OR prop.cgocommune LIKE '42%'  OR prop.cgocommune LIKE '43%'  OR prop.cgocommune LIKE '63%'  OR prop.cgocommune LIKE '69%'  OR prop.cgocommune LIKE '73%'  OR prop.cgocommune LIKE '74%'  )
```
- avec un org ayant une emprise sur un dept + des communes:
```
Resulting geographical SQL filter :  AND ( prop.cgocommune LIKE '38%'  OR prop.cgocommune IN ('070015','070022','070027','070042','070051','070076','070143','070181','070259','070264','070279','070313','070345','070346','070349','260002','260010','260083','260085','260107','260116','260118','260119','260124','260133','260143','260148','260155','260162','260165','260166','260172','260184','260194','260207','260210','260213','260219','260235','260297','260298','260310','260314','260319','260325','260330','260337','260341','260349','260353','260380','420272' )  )

```
pour ce dernier, filtrage ok pour une requete sur le dept ainsi qu'une requete sur une commune