### PR TITLE
Corrections BDD et Demandes

### DIFF
--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/model/request/InformationRequest.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/model/request/InformationRequest.java
@@ -9,10 +9,13 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
@@ -32,7 +35,8 @@ public class InformationRequest implements Serializable{
 	private static final long serialVersionUID = 5439786730972374577L;
 
 	@Id
-	@GeneratedValue
+	@SequenceGenerator(name = "HibernateSequence", sequenceName = "hibernate_sequence", initialValue = 0, allocationSize = 1)
+	@GeneratedValue(generator = "HibernateSequence")
 	private long requestId;
 	
 	@ManyToOne(optional=false, fetch = FetchType.EAGER) 
@@ -43,6 +47,10 @@ public class InformationRequest implements Serializable{
 	private Date requestDate;
 
 	@OneToMany(cascade=CascadeType.ALL, fetch=FetchType.EAGER)
+	@JoinTable(name = "request_information_object_request",
+	          joinColumns = {@JoinColumn(name = "request_information_requestid")},
+	          inverseJoinColumns = {@JoinColumn(name = "objectsrequest_objectid")}
+	)
 	private Set<ObjectRequest> objectsRequest;
 		
 	@Column(name="askby")

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/model/request/ObjectRequest.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/model/request/ObjectRequest.java
@@ -6,6 +6,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
@@ -21,7 +22,8 @@ public class ObjectRequest implements Serializable {
 	private static final long serialVersionUID = 5439786730972374577L;
 
 	@Id
-	@GeneratedValue
+	@SequenceGenerator(name = "HibernateSequence", sequenceName = "hibernate_sequence", initialValue = 0, allocationSize = 1)
+	@GeneratedValue(generator = "HibernateSequence")
 	private long objectId;
 
 	@Column(name = "type")

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/model/request/UserRequest.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/model/request/UserRequest.java
@@ -6,6 +6,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.xml.bind.annotation.XmlAttribute;
 
@@ -19,7 +20,8 @@ public class UserRequest implements Serializable {
 	private static final long serialVersionUID = -9140660737315556020L;
 	
 	@Id
-	@GeneratedValue
+	@SequenceGenerator(name = "HibernateSequence", sequenceName = "hibernate_sequence", initialValue = 0, allocationSize = 1)
+	@GeneratedValue(generator = "HibernateSequence")
 	@Column(name="userid")
 	private long userId;
 		

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/providers/CadastrappInterceptor.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/providers/CadastrappInterceptor.java
@@ -1,6 +1,5 @@
 package org.georchestra.cadastrapp.providers;
 
-import org.apache.commons.lang3.StringUtils;
 import org.georchestra.cadastrapp.service.constants.CadastrappConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/pdf/BordereauParcellaireHelper.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/pdf/BordereauParcellaireHelper.java
@@ -249,6 +249,7 @@ public final class BordereauParcellaireHelper extends CadController{
 		Transformer transformerPDF;
 		JAXBContext jaxbContext;
 		Marshaller jaxbMarshaller;
+		
 		File pdfResult;
 		OutputStream out;
 		Fop fop;
@@ -263,7 +264,7 @@ public final class BordereauParcellaireHelper extends CadController{
 			
 			out = new BufferedOutputStream(new FileOutputStream(pdfResult));
 
-			FopFactoryBuilder builder = new FopFactoryBuilder(pdfResult.toURI());
+			FopFactoryBuilder builder = new FopFactoryBuilder(new File(tempFolder+File.separator+".").toURI());
 			
 			// get DPI from comfig file
 			int dpi=Integer.parseInt(CadastrappPlaceHolder.getProperty("pdf.dpi"));

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/pdf/DemandeController.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/pdf/DemandeController.java
@@ -159,7 +159,7 @@ public class DemandeController extends CadController {
 				// Pdf temporary filename using tmp folder and timestamp
 				final String pdfTmpFileName = tempFolder+File.separator+"DEMANDE_"+new Date().getTime();
 
-				ut.setDestinationFileName(pdfTmpFileName);
+				ut.setDestinationFileName(pdfTmpFileName+".pdf");
 				ut.mergeDocuments(MemoryUsageSetting.setupTempFileOnly());
 
 				File pdfResult = new File(ut.getDestinationFileName());

--- a/cadastrapp/src/main/resources/logback.xml
+++ b/cadastrapp/src/main/resources/logback.xml
@@ -28,7 +28,7 @@
 	<logger name="org.quartz.core.QuartzSchedulerThread" level="WARN" />
 
 	<!-- swagger info --> 
-	<logger name="springfox.documentation" level="DEBUG" />
+	<logger name="springfox.documentation" level="WARN" />
 
 	<appender name="FILE" class="ch.qos.logback.core.FileAppender">
 		<file>/tmp/cadastrapp.log</file>
@@ -38,7 +38,7 @@
 	</appender>
 
 
-	<root level="DEBUG">
+	<root level="INFO">
 		<appender-ref ref="FILE" />
 	</root>
 </configuration>

--- a/cadastrapp/src/main/webapp/WEB-INF/beans.xml
+++ b/cadastrapp/src/main/webapp/WEB-INF/beans.xml
@@ -81,7 +81,7 @@
 				<prop key="hibernate.format_sql">false</prop>
 				<prop key="hibernate.generate_statistics">false</prop>
 				<prop key="hibernate.use_sql_comments">false</prop>
-				<prop key="hibernate.hbm2ddl.auto">validate</prop>
+				<prop key="hibernate.hbm2ddl.auto">none</prop>
 
 			</props>
 		</property>


### PR DESCRIPTION
Corrections : 

- Conserver les mêmes noms de table et séquences utilisés en BDD
- Ajout de l'extension '.pdf' pour les fichiers générés lors d'une demande d'informations
- Correction d'une erreur de génération de l'image dans les BP lors d'une demande d'information
- Réduction des logs par défaut à INFO

Suite à : https://github.com/georchestra/cadastrapp/issues/593