### PR TITLE
Correct handle for get datadir image POST request

### DIFF
--- a/addons/cadastrapp/js/printBordereauParcellaire.js
+++ b/addons/cadastrapp/js/printBordereauParcellaire.js
@@ -109,7 +109,8 @@ GEOR.Addons.Cadastre.initPrintBordereauParcellaireWindow = function(parcelleId) 
         };
         // use request async false to receipt callback
         xhr.open("POST", GEOR.Addons.Cadastre.url.serviceGetImageFromDatadir, false);
-        xhr.send(nameFile); 
+        xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+        xhr.send('imageName='+nameFile); 
         return srcUrl;
     };
     


### PR DESCRIPTION
Actuellement la requête pour récupérer les vignettes de fond de plan pour la génération des BP aboutit sur un http 400.

Probablement suite à la dernière MaJ de spring qui est à présent plus strict sur la forme des paramètres envoyés.

Ce patch corrige ce souci.