### PR TITLE
use parcelle.wms.layer.name when generating SLD_BODY and requesting selected plot image

### DIFF
--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/ImageParcelleController.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/ImageParcelleController.java
@@ -289,6 +289,7 @@ public class ImageParcelleController extends CadController {
 						logger.debug("Call WMS for plot selection layer");
 						// Get cadastral background image with good BBOX
 						final String plotLayerWmsUrl = CadastrappPlaceHolder.getProperty("parcelle.wms.url");	
+						final String plotLayerWmsLayerName = CadastrappPlaceHolder.getProperty("parcelle.wms.layer.name");
 						final String plotLayerWmsUsername = CadastrappPlaceHolder.getProperty("parcelle.wms.username");
 						final String plotLayerWmsPassword = CadastrappPlaceHolder.getProperty("parcelle.wms.password");
 						
@@ -296,13 +297,13 @@ public class ImageParcelleController extends CadController {
 							wmsCadastralLayer = createWebMapServer(plotLayerWmsUrl,plotLayerWmsUsername, plotLayerWmsPassword );
 							
 							//TODO see if specific SRS and format are needed
-							requestCadastralLayer = createAndConfigureMapRequest(wmsCadastralLayer, cadastralLayerFormat, cadastreWFSLayerName, pdfImagePixelSize, cadastreSRS, bounds);
+							requestCadastralLayer = createAndConfigureMapRequest(wmsCadastralLayer, cadastralLayerFormat, plotLayerWmsLayerName, pdfImagePixelSize, cadastreSRS, bounds);
 							cadastreLayerIdParcelle = CadastrappPlaceHolder.getProperty("parcelle.wms.layer.id");
 						}
 																	
 						logger.debug("Create feature image from WMS");
 						
-						StyledLayerDescriptor sld = generateSLD(cadastreWFSLayerName, cadastreLayerIdParcelle, parcelle, styleFillColor, styleFillOpacity, styleStrokeColor, styleStrokeWidth);
+						StyledLayerDescriptor sld = generateSLD(plotLayerWmsLayerName, cadastreLayerIdParcelle, parcelle, styleFillColor, styleFillOpacity, styleStrokeColor, styleStrokeWidth);
 						
 					    SLDTransformer styleTransform = new SLDTransformer();
 				        styleTransform.setEncoding(Charset.forName("UTF-8"));


### PR DESCRIPTION
instead of wrongly reusing `cadastre.wfs.layer.name`. Fixes display of selected
plot on generated BP when using > GS 2.17 and `parcelle.wms.url` points to a
geoserver non-global endpoint, in which case `parcelle.wms.layer.name` shouldn't
contain the workspace prefix otherwise the selected plot style coming from
SLD_BODY is ignored.

eg if you used:
```
parcelle.wms.url=https://georchestra.mydomain.org/geoserver/pci/wms
parcelle.wms.layer.name=pci:geo_parcelle
```
then change the latter for:
```
parcelle.wms.layer.name=geo_parcelle
```