### PR TITLE
dont ignore empty values in createEqualsClauseRequest() (#672)

### DIFF
--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/CadController.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/CadController.java
@@ -309,7 +309,7 @@ public class CadController {
 	 */
 	protected boolean createEqualsClauseRequest(boolean isWhereAdded, StringBuilder sb, String libelle, String value, List<String> paramList) {
 
-		if (value != null && !value.isEmpty()) {
+		if (value != null) {
 			if (!isWhereAdded) {
 				sb.append(" where ");
 				isWhereAdded = true;


### PR DESCRIPTION
`where foo='' and bar='blah'` wont give the same results as `where bar='blah'`. - Fixes #672 but needs careful testing.