### PR TITLE
update backgrounds in sample config to use IGN services

### DIFF
--- a/cadastrapp/src/main/resources/cadastrapp.properties
+++ b/cadastrapp/src/main/resources/cadastrapp.properties
@@ -72,7 +72,7 @@ pdf.baseMap.0.title.thumbnail=https://ids.craig.fr/mapstore/ortho.png
 
 # BaseMap Title to be display in user interface
 pdf.baseMap.0.title=Orthophotographie IGN
-pdf.baseMap.0.wms.url=https://wxs.ign.fr/ortho/geoportail/r/wms
+pdf.baseMap.0.wms.url=https://data.geopf.fr/wms-r/wms
 pdf.baseMap.0.layer.name=HR.ORTHOIMAGERY.ORTHOPHOTOS
 pdf.baseMap.0.format=image/jpeg
 pdf.baseMap.0.SRS=EPSG:3857
@@ -84,7 +84,7 @@ pdf.baseMap.0.wms.password=
 # BaseMap Title to be display in user interface
 pdf.baseMap.1.title=Plan IGN
 pdf.baseMap.1.title.thumbnail=https://ids.craig.fr/mapstore/planign.png
-pdf.baseMap.1.wms.url=https://wxs.ign.fr/essentiels/geoportail/r/wms
+pdf.baseMap.1.wms.url=https://data.geopf.fr/wms-r/wms
 pdf.baseMap.1.layer.name=GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2
 pdf.baseMap.1.format=image/png
 pdf.baseMap.1.SRS=EPSG:3857

--- a/cadastrapp/src/main/resources/cadastrapp.properties
+++ b/cadastrapp/src/main/resources/cadastrapp.properties
@@ -68,7 +68,7 @@ pdf.baseMap.image.folder=images
 # pdf.baseMap.0.title.thumbnail=osm.png
 
 # here we set an URL to use a remote png/jpeg file from another web site 
-pdf.baseMap.1.title.thumbnail=https://ids.craig.fr/mapstore/ortho.png
+pdf.baseMap.0.title.thumbnail=https://ids.craig.fr/mapstore/ortho.png
 
 # BaseMap Title to be display in user interface
 pdf.baseMap.0.title=Orthophotographie IGN

--- a/cadastrapp/src/main/resources/cadastrapp.properties
+++ b/cadastrapp/src/main/resources/cadastrapp.properties
@@ -68,13 +68,13 @@ pdf.baseMap.image.folder=images
 # pdf.baseMap.0.title.thumbnail=osm.png
 
 # here we set an URL to use a remote png/jpeg file from another web site 
-pdf.baseMap.0.title.thumbnail=http://kartenn.region-bretagne.fr/patrimoine/img/basemap/osm_google.png
+pdf.baseMap.1.title.thumbnail=https://ids.craig.fr/mapstore/ortho.png
 
 # BaseMap Title to be display in user interface
-pdf.baseMap.0.title=OSM Google Style - geobretagne
-pdf.baseMap.0.wms.url=http://osm.geobretagne.fr/service/wms?VERSION=1.1.1&Request=GetCapabilities&Service=WMS
-pdf.baseMap.0.layer.name=osm:google
-pdf.baseMap.0.format=image/png
+pdf.baseMap.0.title=Orthophotographie IGN
+pdf.baseMap.0.wms.url=https://wxs.ign.fr/ortho/geoportail/r/wms
+pdf.baseMap.0.layer.name=HR.ORTHOIMAGERY.ORTHOPHOTOS
+pdf.baseMap.0.format=image/jpeg
 pdf.baseMap.0.SRS=EPSG:3857
 # only used when wms service need authentification
 # if empty no authentification is used
@@ -82,16 +82,21 @@ pdf.baseMap.0.wms.username=
 pdf.baseMap.0.wms.password=
 
 # BaseMap Title to be display in user interface
-#pdf.baseMap.1.title=OSM Map Style - geobretagne
-#pdf.basemap.1.title.thumbnail:http://kartenn.region-bretagne.fr/patrimoine/img/basemap/osm.png
-#pdf.baseMap.1.wms.url=http://osm.geobretagne.fr/service/wms?VERSION=1.1.1&Request=GetCapabilities&Service=WMS
-#pdf.baseMap.1.layer.name=osm:map
-#pdf.baseMap.1.format=image/png
-#pdf.baseMap.1.SRS=EPSG:3857
+pdf.baseMap.1.title=Plan IGN
+pdf.baseMap.1.title.thumbnail=https://ids.craig.fr/mapstore/planign.png
+pdf.baseMap.1.wms.url=https://wxs.ign.fr/essentiels/geoportail/r/wms
+pdf.baseMap.1.layer.name=GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2
+pdf.baseMap.1.format=image/png
+pdf.baseMap.1.SRS=EPSG:3857
 ## only used when wms service need authentification
 ## if empty no authentification is used
 #pdf.baseMap.1.wms.username=
 #pdf.baseMap.1.wms.password=
+
+# empty/no basemap
+pdf.baseMap.2.title=Pas de fond
+pdf.baseMap.2.title.thumbnail=https://ids.craig.fr/mapstore/white.png
+pdf.baseMap.2.wms.url=
 ###########################################################
 
 ## information about WMS and WFS service 

--- a/cadastrapp/src/main/resources/cadastrapp.properties
+++ b/cadastrapp/src/main/resources/cadastrapp.properties
@@ -116,8 +116,8 @@ cadastre.wms.password=
 # Note that it must support SLD_BODY WMS param
 # if using geoserver > 2.16 make sure to use a workspace-specific endpoint and
 # don't put the workspace prefix in the layer name
-parcelle.wms.url=
-parcelle.wms.layer.name=
+parcelle.wms.url=https://georchestra.example.org/geoserver/qgis/wms
+parcelle.wms.layer.name=geo_parcelle
 # The plot identifier field for the service
 parcelle.wms.layer.id=
 # only used when wms service need authentification


### PR DESCRIPTION
been using them in production for a while...

@MaelREBOUX @jusabatier @pierrejego your opinion ? after all that's just the default/sample config.

for me the sample existing config bails out when generating a BP:

```
2022-09-14 15:17:03,869 DEBUG [org.georchestra.cadastrapp.service.ImageParcelleController] /cadastrapp/services/getImageBordereau - nouser - norole - noorg - Create webMapServer : http://osm.geobretagne.fr/service/wms?VERSION=1.1.1&Request=GetCapabilities&Service=WMS
2022-09-14 15:17:04,077 ERROR [org.georchestra.cadastrapp.service.ImageParcelleController] /cadastrapp/services/getImageBordereau - nouser - norole - noorg - Error while getting basemap image, no basemap will be displayed on image
org.geotools.ows.ServiceException: Error while parsing XML.
...
        at java.lang.Thread.run(Thread.java:829) [?:?]
Caused by: org.xml.sax.SAXParseException: The element type "hr" must be terminated by the matching end-tag "</hr>".
        at com.sun.org.apache.xerces.internal.util.ErrorHandlerWrapper.createSAXParseException(ErrorHandlerWrapper.java:204) ~[?:?]
```
(but there's no `<hr>` element in the getcapabilities ?)