### PR TITLE
don't enforce WMS 1.1.1 in WMS queries for BP exports

### DIFF
--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/ImageParcelleController.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/ImageParcelleController.java
@@ -80,7 +80,7 @@ public class ImageParcelleController extends CadController {
 	static final Logger logger = LoggerFactory.getLogger(ImageParcelleController.class);
 
 	private final String URL_GET_CAPABILITIES = "?REQUEST=GetCapabilities&version=1.0.0";
-	private final String URL_GET_CAPABILITIES_WMS = "?VERSION=1.1.1&Request=GetCapabilities&Service=WMS";
+	private final String URL_GET_CAPABILITIES_WMS = "?Request=GetCapabilities&Service=WMS";
 	
 	// buffer ratio
 	final private double MAX_PERIMETER = 2000;


### PR DESCRIPTION
baseMap uses geopf since 8d75eb2 and per
https://geoservices.ign.fr/bascule-vers-la-geoplateforme the service doesn't support this deprecated version, only 1.3.0

no regression on BP exports after light testing, using cadastre layer coming from mapproxy and plot layer with SLD_BODY coming from geoserver

closes #737