### PR TITLE
bump maven-war-plugin to 3.4.0 to fix build with java17

### DIFF
--- a/cadastrapp/pom.xml
+++ b/cadastrapp/pom.xml
@@ -381,7 +381,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-war-plugin</artifactId>
-            <version>2.2</version>
+            <version>3.4.0</version>
             <configuration>
               <classifier>generic</classifier>
               <warName>${project.artifactId}</warName>


### PR DESCRIPTION
fixes `mvn -PdebianPackage install` here with java 17. runtime is fine anyway..

interestingly, if i dont use `-PdebianPackage`, the build still uses war-plugin 2.2 (and fails), which isn't declared as a dependency anywhere.. maybe because of https://github.com/georchestra/cadastrapp/blob/master/pom.xml#L46 ?