### PR TITLE
allow to use a distinct url/layername for background in BPs

### DIFF
--- a/.github/workflows/cadastrapp.yml
+++ b/.github/workflows/cadastrapp.yml
@@ -16,6 +16,7 @@ jobs:
     - name: "Setting up Java"
       uses: actions/setup-java@v4
       with:
+        distribution: 'adopt'
         java-version: '17'
 
     - name: "Maven repository caching"
@@ -51,6 +52,7 @@ jobs:
     - name: "Setting up Java"
       uses: actions/setup-java@v4
       with:
+        distribution: 'adopt'
         java-version: '17'
 
     - name: "Maven repository caching"

--- a/.github/workflows/cadastrapp.yml
+++ b/.github/workflows/cadastrapp.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Checking out"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: "Setting up Java"
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
         java-version: '17'
 
@@ -46,15 +46,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Checking out"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: "Setting up Java"
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
         java-version: '17'
 
     - name: "Maven repository caching"
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: cadastrapp-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/cadastrapp.yml
+++ b/.github/workflows/cadastrapp.yml
@@ -19,7 +19,7 @@ jobs:
         java-version: '17'
 
     - name: "Maven repository caching"
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ~/.m2/repository
         key: cadastrapp-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -37,7 +37,7 @@ jobs:
       run: mkdir -p scratch && cp cadastrapp/target/georchestra-cadastrapp*.deb scratch/
 
     - name: "publish deb as artifact"
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: cadastrapp.deb
         path: scratch/

--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/ImageParcelleController.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/ImageParcelleController.java
@@ -269,16 +269,22 @@ public class ImageParcelleController extends CadController {
 
 						logger.debug("Call WMS for cadastral background");
 						// Get cadastral background image with good BBOX
-						final String cadastralLayerWmsUrl = CadastrappPlaceHolder.getProperty("cadastre.wms.url");				
+						String cadastralLayerWmsUrl = CadastrappPlaceHolder.getProperty("cadastre.wms.url");
 						final String cadastralLayerWmsUsername = CadastrappPlaceHolder.getProperty("cadastre.wms.username");
 						final String cadastralLayerWmsPassword = CadastrappPlaceHolder.getProperty("cadastre.wms.password");
-						
+						// overriden by cadastrebpbg if defined - allows to use a different layer source url for backgrounds in BPs
+						if (CadastrappPlaceHolder.getProperty("cadastrebpbg.wms.url") != null && !CadastrappPlaceHolder.getProperty("cadastrebpbg.wms.url").isEmpty()) {
+							cadastralLayerWmsUrl = CadastrappPlaceHolder.getProperty("cadastrebpbg.wms.url");
+						}
 						WebMapServer wmsCadastralLayer = createWebMapServer(cadastralLayerWmsUrl,cadastralLayerWmsUsername, cadastralLayerWmsPassword );
 									
-						final String cadastralLayerName = CadastrappPlaceHolder.getProperty("cadastre.wms.layer.name");
+						String cadastralLayerName = CadastrappPlaceHolder.getProperty("cadastre.wms.layer.name");
 						final String cadastreSRS = CadastrappPlaceHolder.getProperty("cadastre.SRS");
 						final String cadastralLayerFormat = CadastrappPlaceHolder.getProperty("cadastre.format");
-						
+						// overriden by cadastrebpbg if defined - allows to use a different layer name for backgrounds in BPs
+						if (CadastrappPlaceHolder.getProperty("cadastrebpbg.wms.layer.name") != null && !CadastrappPlaceHolder.getProperty("cadastrebpbg.wms.layer.name").isEmpty()) {
+							cadastralLayerName = CadastrappPlaceHolder.getProperty("cadastrebpbg.wms.layer.name");
+						}
 						GetMapRequest requestCadastralLayer = createAndConfigureMapRequest(wmsCadastralLayer, cadastralLayerFormat, cadastralLayerName, pdfImagePixelSize, cadastreSRS, bounds);
 																		
 						logger.debug("Create background cadastral image");

--- a/cadastrapp/src/main/resources/cadastrapp.properties
+++ b/cadastrapp/src/main/resources/cadastrapp.properties
@@ -111,6 +111,11 @@ cadastre.wms.layer.name=qgis:geo_parcelle
 cadastre.wms.username=
 cadastre.wms.password=
 
+#if defined, used instead of cadastre.wms for the background layer in BP
+#useful of cadastre.wms points at a cached layer and you want a different layer without resampling for BPs.
+#cadastrebpbg.wms.url=https://georchestra.example.org/geoserver/wms
+#cadastrebpbg.wms.layer.name=qgis:geo_parcelle
+
 # Here you can configure the layer used to generate the plot selection on BP
 # let it empty if cadastre.wms.url support SLD_BODY WMS param
 # Note that it must support SLD_BODY WMS param


### PR DESCRIPTION
sometimes we dont want to use the same layer in the web interface (where the zoom levels are known and the WMS is backed by a cached layer) and in the BP (when the zoom level depends on the plot size and we might want an uncached layer).