### PR TITLE
feat: making timeout for WFS calls configureable

### DIFF
--- a/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/ImageParcelleController.java
+++ b/cadastrapp/src/main/java/org/georchestra/cadastrapp/service/ImageParcelleController.java
@@ -59,6 +59,7 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.referencing.operation.TransformException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -84,6 +85,9 @@ public class ImageParcelleController extends CadController {
 	
 	// buffer ratio
 	final private double MAX_PERIMETER = 2000;
+
+    @Value("${wfsTimeout:3000}")
+    private int wfsTimeout;
 
 
 	/**
@@ -132,7 +136,7 @@ public class ImageParcelleController extends CadController {
 			Map<String, Serializable> connectionParameters = new HashMap<String, Serializable>();
 			connectionParameters.put(WFSDataStoreFactory.URL.key, getCapabilities);
 			connectionParameters.put(WFSDataStoreFactory.TRY_GZIP.key, Boolean.TRUE);
-			
+			connectionParameters.put(WFSDataStoreFactory.TIMEOUT.key, wfsTimeout);
 			// Add basic authent parameter if not empty
 			final String cadastreWFSUsername = CadastrappPlaceHolder.getProperty("cadastre.wfs.username");
 			final String cadastreWFSPassword = CadastrappPlaceHolder.getProperty("cadastre.wfs.password");
@@ -145,7 +149,7 @@ public class ImageParcelleController extends CadController {
 
 			try {
 				dataStore = DataStoreFinder.getDataStore(connectionParameters);
-				
+
 				// check all typeName, geo_parcelle are sometimes visibile in geoserver but not here
 				// redeploy in geoserver is needed
 				if(logger.isDebugEnabled()){

--- a/cadastrapp/src/main/resources/cadastrapp.properties
+++ b/cadastrapp/src/main/resources/cadastrapp.properties
@@ -168,5 +168,6 @@ purge.hours=24
 # See http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/crontrigger.html for example
 purge.cronExpression=0 0 * * * ?
 
-
-
+# GeoTools WFS timeout, defaults to GeoTools library default, 3000ms
+# See https://github.com/geotools/geotools/blob/main/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/impl/WFSDataAccessFactory.java#L210-L223
+#wfsTimeout=3000


### PR DESCRIPTION
In some cases, 3 seconds for read timeouts on WFS queries can be not enough. If the timeout is reached, then the call to /getImageBordereau can lead to have a blank "BP" generated. Once called once or twice, sometimes the consecutive calls are fast enough to get correctly generated though.

We encountered this behaviour in several of our clients' environments, so giving the possibility to increase the timeout sounds as a "good enough" workaround.

Tests: runtime-tested at cadastrapp bootstrap using the jetty maven plugin in various configurations:

```
(no value defined for wfsTimeout)
$ mvn jetty:run
=> ImageParcelleController.wfsTimeout = 3000

(value set to 30000 in the cadastrapp.properties classpath file)
$ mvn jetty:run
=> ImageParcelleController.wfsTimeout = 30000

(value set to 60000 in /tmp/cadastrapp/cadastrapp.properties)
$ mvn jetty:run -Dgeorchestra.datadir=/tmp
=> ImageParcelleController.wfsTimeout = 60000
```